### PR TITLE
Expose Bridge stable test workflows on main

### DIFF
--- a/.github/workflows/bridge-stable-test-deploy-v1.yml
+++ b/.github/workflows/bridge-stable-test-deploy-v1.yml
@@ -1,0 +1,47 @@
+name: bridge-stable-test-deploy-v1
+
+on:
+  workflow_dispatch:
+    inputs:
+      bridge_ref:
+        description: "Git ref containing the Bridge payload and deploy candidate scripts"
+        required: true
+        default: "dev/bridge"
+
+jobs:
+  deploy_bridge_stable:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.bridge_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Apply stable Bridge payload
+        shell: bash
+        run: |
+          bash components/scale-radio-bridge/deploy_candidates/022c2_stable_apply.sh
+
+      - name: Healthcheck stable Bridge payload
+        shell: bash
+        run: |
+          bash components/scale-radio-bridge/deploy_candidates/022c2_stable_healthcheck.sh
+
+      - name: Roll back stable Bridge payload on failure
+        if: failure()
+        shell: bash
+        run: |
+          bash components/scale-radio-bridge/deploy_candidates/022c2_stable_remove.sh

--- a/.github/workflows/bridge-stable-test-rollback-v1.yml
+++ b/.github/workflows/bridge-stable-test-rollback-v1.yml
@@ -1,0 +1,32 @@
+name: bridge-stable-test-rollback-v1
+
+on:
+  workflow_dispatch:
+    inputs:
+      bridge_ref:
+        description: "Git ref containing the Bridge remove script"
+        required: true
+        default: "dev/bridge"
+
+jobs:
+  rollback_bridge_stable:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.bridge_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+
+      - name: Remove stable Bridge payload from active runtime
+        shell: bash
+        run: |
+          bash components/scale-radio-bridge/deploy_candidates/022c2_stable_remove.sh


### PR DESCRIPTION
This PR makes the first Bridge test workflows manually runnable from the Actions UI by placing the workflow files on the default branch.

Included:
- `bridge-stable-test-deploy-v1.yml`
- `bridge-stable-test-rollback-v1.yml`

Workflow behavior:
- manual trigger only
- checks out a configurable Git ref, defaulting to `dev/bridge`
- runs on `[self-hosted, scale-radio, pi]`
- deploy workflow applies the stable Bridge payload, runs the healthcheck, and rolls back on failure
- rollback workflow removes the active stable Bridge runtime from the live Volumio path

Why this PR exists:
GitHub only shows manually runnable workflows in the Actions UI when the workflow file exists on the default branch. This PR makes the Bridge test lane visible and usable while still executing against `dev/bridge` by default.
