### PR TITLE
Finalize Git ops structure and generic deploy workflows

### DIFF
--- a/.github/workflows/component-test-deploy-v3.yml
+++ b/.github/workflows/component-test-deploy-v3.yml
@@ -1,0 +1,78 @@
+name: component-test-deploy-v3
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Apply selected payload
+        shell: bash
+        run: |
+          case "${{ inputs.component }}" in
+            bridge)
+              bash components/scale-radio-bridge/deploy_candidates/apply_payload_v2.sh "${{ inputs.payload }}"
+              ;;
+            *)
+              echo "Unsupported component: ${{ inputs.component }}"
+              exit 2
+              ;;
+          esac
+
+      - name: Healthcheck selected payload
+        shell: bash
+        run: |
+          case "${{ inputs.component }}" in
+            bridge)
+              bash components/scale-radio-bridge/deploy_candidates/healthcheck_runtime_v2.sh "${{ inputs.payload }}"
+              ;;
+            *)
+              echo "Unsupported component: ${{ inputs.component }}"
+              exit 2
+              ;;
+          esac
+
+      - name: Roll back selected payload on failure
+        if: failure()
+        shell: bash
+        run: |
+          case "${{ inputs.component }}" in
+            bridge)
+              bash components/scale-radio-bridge/deploy_candidates/remove_active_v2.sh "${{ inputs.payload }}"
+              ;;
+            *)
+              echo "Unsupported component: ${{ inputs.component }}"
+              exit 2
+              ;;
+          esac

--- a/.github/workflows/component-test-rollback-v3.yml
+++ b/.github/workflows/component-test-rollback-v3.yml
@@ -1,0 +1,48 @@
+name: component-test-rollback-v3
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+
+      - name: Remove selected payload from active runtime
+        shell: bash
+        run: |
+          case "${{ inputs.component }}" in
+            bridge)
+              bash components/scale-radio-bridge/deploy_candidates/remove_active_v2.sh "${{ inputs.payload }}"
+              ;;
+            *)
+              echo "Unsupported component: ${{ inputs.component }}"
+              exit 2
+              ;;
+          esac

--- a/contracts/deployment/deployment_decisions_v1.md
+++ b/contracts/deployment/deployment_decisions_v1.md
@@ -1,0 +1,46 @@
+# DEPLOYMENT DECISIONS V1
+
+## Leading rule
+Deployment uses clean-replace semantics, not update-in-place semantics.
+
+## Required deploy sequence
+1. detect whether a live version is installed
+2. move the currently active plugin runtime out of the active Volumio paths
+3. move the currently active plugin configuration out of the active Volumio paths
+4. copy the selected payload into the live plugin path
+5. run the payload `install.sh`
+6. restart Volumio
+7. wait for Volumio recovery
+8. run baseline recovery checks
+9. run component-specific healthcheck
+10. leave the component installed for functional testing
+
+## Required rollback sequence
+1. move the active plugin runtime out of the active Volumio path
+2. move the active plugin configuration out of the active Volumio path
+3. unregister the plugin from Volumio's enabled plugin state when applicable
+4. restart Volumio
+5. wait for recovery
+6. verify baseline runtime recovery
+
+## Baseline recovery checks
+- `volumio` active
+- `volumio-kiosk` active
+- `Xorg` present
+- `chromium` present
+
+## Workflow rule
+- workflows live on `main`
+- workflows must accept a `git_ref` input
+- workflows must accept component-specific release selectors where needed, for example `payload`
+- workflows must be manually runnable by the operator from the Actions UI
+
+## Payload rule
+- payloads committed to Git must be extracted file trees, not only ZIP archives
+- payloads live under `components/<component>/payload/<release_name>/`
+
+## Current bridge rule
+The Bridge deploy lane already proved:
+- stable payload install works from `dev/bridge`
+- overlay on `:5511` is reachable
+- plugin may remain inactive after install and that is acceptable for now

--- a/docs/ops/release_creation_path_v1.md
+++ b/docs/ops/release_creation_path_v1.md
@@ -1,0 +1,25 @@
+# RELEASE CREATION PATH V1
+
+## Goal
+This path tells a specialist chat how to prepare a release that the operator can deploy from GitHub Actions.
+
+## Steps
+1. choose the correct `dev/<component>` branch
+2. add the extracted release payload under `components/<component>/payload/<release_name>/`
+3. make or update deploy candidate scripts so they can install, healthcheck, and remove that payload
+4. keep repo-facing text in English
+5. write or update the component journal stream/current state if the work changed agreements or status
+6. run the deploy workflow from `main` against the `dev/<component>` branch
+7. test on Pi
+8. if the result is not acceptable, run the rollback workflow
+9. only open a focused PR to `main` after the release is acceptable
+
+## Required release contents
+- extracted payload tree
+- install path logic
+- healthcheck logic
+- remove/rollback logic
+- any contract updates needed by the change
+
+## PR rule
+PRs to `main` should be focused and release-oriented. Do not use one giant component accumulation PR as the normal model.

--- a/docs/ops/repo_execution_path_v1.md
+++ b/docs/ops/repo_execution_path_v1.md
@@ -1,0 +1,48 @@
+# REPO EXECUTION PATH V1
+
+## Purpose
+This document is the short operating path for any specialist chat that needs to continue development from the repository.
+
+## Read order
+1. `contracts/repo/branch_strategy_v1.md`
+2. `contracts/volumio4/volumio4_plugin_config_contract_v1.md`
+3. `contracts/hardware/hardware_config_contract_v2.md`
+4. `contracts/coding/coding_standard_v1.md`
+5. `contracts/gui/gui_foundation_v1.md`
+6. `contracts/observability/performance_status_matrix_v1.md`
+7. `contracts/deployment/deployment_decisions_v1.md`
+8. `docs/ops/release_creation_path_v1.md`
+
+## Branch rules
+- `main` = stable, manually runnable workflows live here
+- `integration/staging` = integration-owned control-plane work
+- `dev/<component>` = component development and payload work
+
+## Required workflow model
+- workflows live on `main`
+- workflows accept a branch/ref input
+- operator runs workflows manually from the Actions UI
+- workflow checks out the selected branch/ref and executes the selected payload/scripts from there
+
+## Release path
+1. work on `dev/<component>`
+2. add exact extracted payload files under `components/<component>/payload/<release_name>/`
+3. make deploy candidate scripts work from that payload
+4. run deploy workflow from `main` against `dev/<component>`
+5. test on Pi
+6. if not acceptable, run rollback workflow
+7. only then open a focused PR to `main`
+
+## Access expectation for specialist chats
+A specialist chat must be able to:
+- read the repository contracts and current payloads
+- commit to its `dev/<component>` branch
+- open a PR when the release is stable enough
+
+The operator must be able to:
+- run the workflows from `main`
+- inspect results
+- trigger rollback
+
+## Important limit
+Repository documentation can standardize the process, but it does not grant GitHub tool access by itself. If a specialist chat cannot write to Git directly, it must still produce repo-ready output and hand it to the integration chat or the operator for commit.


### PR DESCRIPTION
This PR finalizes the repository operating path and exposes generic manual deploy/rollback workflows on the default branch.

Included:
- repo execution instructions for specialist chats
- deployment decisions document
- release creation path document
- generic manual deploy workflow on `main`
- generic manual rollback workflow on `main`

Workflow model:
- workflows live on `main`
- operator selects `git_ref`, `component`, and `payload`
- workflow checks out the selected ref and runs the component deploy/remove scripts from there

Current implemented component lane:
- `bridge`
- payloads live on `dev/bridge`
- deploy/remove scripts use clean-replace semantics and restart Volumio

Note:
- PR #14 should not be merged as-is. It is a large accumulated dev branch PR from an outdated merge base and is currently conflicted. The safer path is to keep `dev/bridge` as the working lane, use the new generic workflows from `main`, and later open a focused Bridge release PR after the branch is realigned to current `main`.
