### PR TITLE
Ship repo-managed deploy wrapper and v4 workflows

### DIFF
--- a/.github/workflows/component-test-deploy-v4.yml
+++ b/.github/workflows/component-test-deploy-v4.yml
@@ -1,0 +1,55 @@
+name: component-test-deploy-v4
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Install repo-shipped sr-deploy wrapper
+        shell: bash
+        run: |
+          sudo cp tools/deploy/sr-deploy-wrapper.sh /usr/local/bin/sr-deploy
+          sudo chmod 755 /usr/local/bin/sr-deploy
+
+      - name: Apply selected payload via repo wrapper
+        shell: bash
+        run: |
+          sr-deploy deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"
+
+      - name: Roll back selected payload on failure
+        if: failure()
+        shell: bash
+        run: |
+          sr-deploy rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"

--- a/.github/workflows/component-test-rollback-v4.yml
+++ b/.github/workflows/component-test-rollback-v4.yml
@@ -1,0 +1,46 @@
+name: component-test-rollback-v4
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+
+      - name: Install repo-shipped sr-deploy wrapper
+        shell: bash
+        run: |
+          sudo cp tools/deploy/sr-deploy-wrapper.sh /usr/local/bin/sr-deploy
+          sudo chmod 755 /usr/local/bin/sr-deploy
+
+      - name: Roll back selected payload via repo wrapper
+        shell: bash
+        run: |
+          sr-deploy rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"

--- a/tools/deploy/sr-deploy-wrapper.sh
+++ b/tools/deploy/sr-deploy-wrapper.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+COMPONENT="${2:-}"
+PAYLOAD="${3:-}"
+REPO_ROOT="${4:-${GITHUB_WORKSPACE:-}}"
+
+if [[ -z "$ACTION" || -z "$COMPONENT" || -z "$PAYLOAD" || -z "$REPO_ROOT" ]]; then
+  echo "Usage: sr-deploy <deploy|rollback> <component> <payload> <repo_root>"
+  exit 1
+fi
+
+case "$COMPONENT" in
+  bridge)
+    BASE="$REPO_ROOT/components/scale-radio-bridge/deploy_candidates"
+    APPLY="$BASE/apply_payload_v2.sh"
+    HEALTH="$BASE/healthcheck_runtime_v2.sh"
+    REMOVE="$BASE/remove_active_v2.sh"
+    ;;
+  *)
+    echo "Unsupported component: $COMPONENT"
+    exit 2
+    ;;
+esac
+
+case "$ACTION" in
+  deploy)
+    bash "$APPLY" "$PAYLOAD"
+    bash "$HEALTH" "$PAYLOAD"
+    ;;
+  rollback)
+    bash "$REMOVE" "$PAYLOAD"
+    ;;
+  *)
+    echo "Unsupported action: $ACTION"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
This PR moves the deployment entrypoint into the repository and removes dependence on a stale preinstalled bootstrap wrapper.

Included:
- `tools/deploy/sr-deploy-wrapper.sh`
- `component-test-deploy-v4.yml`
- `component-test-rollback-v4.yml`

Behavior:
- workflows still run from `main`
- workflows check out the selected `git_ref`
- workflows install the repo-shipped `sr-deploy` wrapper on the target during the run
- deploy and rollback then execute through the repo-managed wrapper against the checked-out repo contents

Current supported component:
- bridge
