### PR TITLE
Add v5 deploy workflows without sudo wrapper install

### DIFF
--- a/.github/workflows/component-test-deploy-v5.yml
+++ b/.github/workflows/component-test-deploy-v5.yml
@@ -1,0 +1,49 @@
+name: component-test-deploy-v5
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Apply selected payload via repo wrapper
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"
+
+      - name: Roll back selected payload on failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"

--- a/.github/workflows/component-test-rollback-v5.yml
+++ b/.github/workflows/component-test-rollback-v5.yml
@@ -1,0 +1,40 @@
+name: component-test-rollback-v5
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+
+      - name: Roll back selected payload via repo wrapper
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE"


### PR DESCRIPTION
This patch fixes the v4 workflow failure on runners without passwordless sudo.

Included:
- `component-test-deploy-v5.yml`
- `component-test-rollback-v5.yml`

Behavior:
- no installation of `/usr/local/bin/sr-deploy`
- no `sudo cp`
- workflows call the repo-shipped wrapper directly from the checked-out repository
- still fully repo-driven and multi-Pi safe

Current supported component:
- bridge
