### PR TITLE
Add v6 deploy workflows

### DIFF
--- a/.github/workflows/component-test-deploy-v6.yml
+++ b/.github/workflows/component-test-deploy-v6.yml
@@ -1,0 +1,55 @@
+name: component-test-deploy-v6
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow/control-plane repository state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Apply selected payload via repo wrapper
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Roll back selected payload on failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"

--- a/.github/workflows/component-test-rollback-v6.yml
+++ b/.github/workflows/component-test-rollback-v6.yml
@@ -1,0 +1,46 @@
+name: component-test-rollback-v6
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "022c2_stable"
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p /opt/scale-radio/removed/bridge
+          test -w /opt/scale-radio/state
+          test -w /opt/scale-radio/removed/bridge
+
+      - name: Roll back selected payload via repo wrapper
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"


### PR DESCRIPTION
Fix v5 path issue by using dual checkout.

- checkout main for workflows and wrapper
- checkout selected git_ref into target_ref
- run wrapper from main against target_ref
- no sudo and no system-wide wrapper install
