### PR TITLE
Reduce overlay white-flash and tighten pointer/hidden-state tuning (1.10.3)

### DIFF
--- a/components/scale-radio-tuner/payload/current/CHANGELOG.md
+++ b/components/scale-radio-tuner/payload/current/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.10.3
+- browse-open path now waits briefly for renderer-ready to reduce pre-overlay white flashes
+- resident reveal paints an immediate dark pre-frame before the first normal draw cycle
+- smoother pointer tuning defaults (higher visible FPS cap, lower deadbands, faster follow gains)
+- hidden standby visibility reaction tightened with lower hidden reload/sleep intervals
+
 ## 1.10.2
 - first-show pointer hydration fix
 - exit UI pre-roll to reduce white flashes

--- a/components/scale-radio-tuner/payload/current/config.json
+++ b/components/scale-radio-tuner/payload/current/config.json
@@ -184,11 +184,11 @@
     "type": "string"
   },
   "pointerVisualFollowGain": {
-    "value": 0.42,
+    "value": 0.5,
     "type": "number"
   },
   "pointerVisualLockedGain": {
-    "value": 0.52,
+    "value": 0.62,
     "type": "number"
   },
   "pointerJitterEnabled": {
@@ -215,6 +215,14 @@
     "value": 0.003,
     "type": "number"
   },
+  "pointerVisualDeadbandMHz": {
+    "value": 0.004,
+    "type": "number"
+  },
+  "pointerPixelSnapDeadbandPx": {
+    "value": 0.5,
+    "type": "number"
+  },
   "rendererReadyWaitMs": {
     "value": 2200,
     "type": "number"
@@ -236,11 +244,11 @@
     "type": "number"
   },
   "visibleFpsCap": {
-    "value": 24,
+    "value": 30,
     "type": "number"
   },
   "hiddenStateReloadMs": {
-    "value": 2000,
+    "value": 180,
     "type": "number"
   },
   "deepIdleReloadMs": {
@@ -248,7 +256,7 @@
     "type": "number"
   },
   "hiddenStandbySleepMs": {
-    "value": 250,
+    "value": 70,
     "type": "number"
   },
   "deepIdleSleepMs": {

--- a/components/scale-radio-tuner/payload/current/index.js
+++ b/components/scale-radio-tuner/payload/current/index.js
@@ -509,7 +509,9 @@ ControllerRadioScalePeppy.prototype.handleBrowseUri = function (curUri) {
     .then(() => {
       this.logger.info('[radio_scale_peppy] handleBrowseUri ' + uri);
       if (uri === this.browseSourceUri || uri === this.browseSourceUri + '/open') {
-        return this.openScale(false).then(() => this.getBrowseRoot(true));
+        return this.openScale(false)
+          .then(() => this.waitForRendererReadyBriefly(this.getNumberConfig('rendererReadyWaitMs', 2200)))
+          .then(() => this.getBrowseRoot(true));
       }
 
       if (uri === this.browseSourceUri + '/close') {
@@ -643,7 +645,7 @@ ControllerRadioScalePeppy.prototype.waitForRendererReadyBriefly = function (time
     if (Date.now() >= deadline) {
       return Promise.resolve({ success: true, ready: false, timeout: true });
     }
-    return this.delay(40).then(poll);
+    return this.delay(25).then(poll);
   };
   return poll();
 };
@@ -1855,6 +1857,8 @@ ControllerRadioScalePeppy.prototype.writeSettingsFile = function () {
     pointer_idle_lock_ms: this.getNumberConfig('pointerIdleLockMs', 220),
     pointer_startup_settle_ms: this.getNumberConfig('pointerStartupSettleMs', 900),
     pointer_settle_epsilon_mhz: this.getNumberConfig('pointerSettleEpsilonMHz', 0.004),
+    pointer_visual_deadband_mhz: this.getNumberConfig('pointerVisualDeadbandMHz', 0.0045),
+    pointer_pixel_snap_deadband_px: this.getNumberConfig('pointerPixelSnapDeadbandPx', 0.5),
     hiss_start_delay_ms: this.getNumberConfig('hissStartDelayMs', 1600),
     pointer_jitter_enabled: this.getBooleanConfig('pointerJitterEnabled', false) === true,
     lock_visual_snap_enabled: this.getBooleanConfig('lockVisualSnapEnabled', false) === true,

--- a/components/scale-radio-tuner/payload/current/renderer/radio_scale_renderer.py
+++ b/components/scale-radio-tuner/payload/current/renderer/radio_scale_renderer.py
@@ -360,6 +360,10 @@ class RadioScaleRenderer:
         flags = self.build_display_flags(desired_visible)
         self.screen = pygame.display.set_mode(self.size, flags)
         pygame.display.set_caption('Scale FM Overlay')
+        if desired_visible:
+            # Draw a dark frame immediately on reveal so X11/SDL mode switches do
+            # not expose a bright intermediate frame before the normal draw pass.
+            self.present_startup_splash()
         self.last_ui_mode = str(self.state.get('ui_mode') or 'normal').lower()
 
     def init_theme(self):


### PR DESCRIPTION
### Motivation

- Reduce brief white/bright flashes when the fullscreen overlay is revealed and make the first visible frame more reliable. 
- Improve pointer responsiveness and stability by adjusting follow/locked gains and introducing deadbands and pixel snap tuning. 
- Make hidden/standby reaction faster by tightening reload and sleep intervals.

### Description

- Added `1.10.3` notes to `CHANGELOG.md` documenting the UI/renderer and tuning changes. 
- Updated `config.json` to raise `pointerVisualFollowGain` to `0.5` and `pointerVisualLockedGain` to `0.62`, added `pointerVisualDeadbandMHz` and `pointerPixelSnapDeadbandPx`, increased `visibleFpsCap` to `30`, and shortened `hiddenStateReloadMs` and `hiddenStandbySleepMs`. 
- In `index.js` the browse flow now waits briefly for the renderer after opening (`waitForRendererReadyBriefly` using `rendererReadyWaitMs`), the poll delay in that waiter was reduced from `40ms` to `25ms`, and new settings keys `pointer_visual_deadband_mhz` and `pointer_pixel_snap_deadband_px` are written via `writeSettingsFile`. 
- In `renderer/radio_scale_renderer.py` the renderer draws an immediate dark startup splash on reveal by calling `present_startup_splash()` to avoid exposing a bright intermediate frame before the normal draw pass.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe9e6e5248324accea2886e29f4a9)