### PR TITLE
Add initial repo guard CI

### DIFF
--- a/.github/workflows/repo-guard-v1.yml
+++ b/.github/workflows/repo-guard-v1.yml
@@ -1,0 +1,27 @@
+name: repo-guard-v1
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  repo_integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run repo integrity checks
+        shell: bash
+        run: |
+          bash tools/ci/check_repo_integrity.sh
+
+  shell_syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run shell syntax checks
+        shell: bash
+        run: |
+          bash tools/ci/check_shell_syntax.sh

--- a/tools/ci/check_repo_integrity.sh
+++ b/tools/ci/check_repo_integrity.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "CI: $1"; exit 1; }
+
+if find . \( -name '__pycache__' -o -name '*.pyc' \) | grep -q .; then
+  find . \( -name '__pycache__' -o -name '*.pyc' \)
+  fail "Python cache artifacts are not allowed"
+fi
+
+for path in \
+  contracts/repo/release_intake_and_delivery_status_v1.md \
+  contracts/repo/component_journal_policy_v1.md \
+  contracts/repo/repository_language_standard_v1.md
+ do
+  if [[ -f "$path" ]] && grep -Eq '^# placeholder$' "$path"; then
+    fail "Placeholder governance doc still present: $path"
+  fi
+done
+
+for path in \
+  contracts/repo/release_intake_and_delivery_status_v2.md \
+  contracts/repo/component_journal_policy_v2.md \
+  contracts/repo/repository_language_standard_v2.md \
+  journals/system-integration-normalization/STATUS_system_integration_normalization_v1.md \
+  journals/system-integration-normalization/DECISIONS_system_integration_normalization_v1.md \
+  .github/workflows/component-test-deploy-v6.yml \
+  .github/workflows/component-test-rollback-v6.yml
+ do
+  [[ -f "$path" ]] || fail "Missing required file: $path"
+done
+
+for path in \
+  .github/workflows/component-test-deploy-v3.yml \
+  .github/workflows/component-test-deploy-v4.yml \
+  .github/workflows/component-test-deploy-v5.yml \
+  .github/workflows/component-test-rollback-v3.yml \
+  .github/workflows/component-test-rollback-v4.yml \
+  .github/workflows/component-test-rollback-v5.yml
+ do
+  [[ ! -f "$path" ]] || fail "Obsolete workflow still present: $path"
+done
+
+echo "CI: repo integrity checks passed"

--- a/tools/ci/check_shell_syntax.sh
+++ b/tools/ci/check_shell_syntax.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t files < <(find . -type f -name '*.sh' | sort)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "CI: no shell scripts found"
+  exit 0
+fi
+
+for file in "${files[@]}"; do
+  echo "CI: bash -n $file"
+  bash -n "$file"
+done
+
+echo "CI: shell syntax checks passed"


### PR DESCRIPTION
Starts real CI enforcement.

Included:
- `tools/ci/check_repo_integrity.sh`
- `tools/ci/check_shell_syntax.sh`
- `repo-guard-v1.yml`

What it enforces now:
- no Python cache artifacts in repo
- required governance/status files exist
- obsolete component workflow generations are gone
- shell scripts pass `bash -n`

This is the first CI step and can be extended later with stricter policy checks.
