### PR TITLE
Add corrected repo guard CI v2

### DIFF
--- a/.github/workflows/repo-guard-v2.yml
+++ b/.github/workflows/repo-guard-v2.yml
@@ -1,0 +1,31 @@
+name: repo-guard-v2
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  repo_guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run repo guard checks
+        shell: bash
+        run: |
+          bash tools/ci/check_repo_guard_v2.sh
+
+  shell_syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run shell syntax checks
+        shell: bash
+        run: |
+          bash tools/ci/check_shell_syntax_v2.sh

--- a/tools/ci/check_repo_guard_v2.sh
+++ b/tools/ci/check_repo_guard_v2.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "CI: $1"; exit 1; }
+
+allowed_pycache="components/scale-radio-tuner/payload/current/renderer/__pycache__/radio_scale_renderer.cpython-313.pyc"
+
+mapfile -t pycache_hits < <(find . \( -name '__pycache__' -o -name '*.pyc' \) | sed 's#^./##' | sort)
+for hit in "${pycache_hits[@]:-}"; do
+  [[ -z "$hit" ]] && continue
+  if [[ "$hit" != "$allowed_pycache" ]]; then
+    echo "$hit"
+    fail "Unexpected Python cache artifact present"
+  fi
+done
+
+echo "CI: checking required governance and status files"
+for path in \
+  contracts/repo/release_intake_and_delivery_status_v2.md \
+  contracts/repo/component_journal_policy_v2.md \
+  contracts/repo/repository_language_standard_v2.md \
+  journals/system-integration-normalization/STATUS_system_integration_normalization_v1.md \
+  journals/system-integration-normalization/DECISIONS_system_integration_normalization_v1.md \
+  .github/workflows/component-test-deploy-v6.yml \
+  .github/workflows/component-test-rollback-v6.yml
+ do
+  [[ -f "$path" ]] || fail "Missing required file: $path"
+ done
+
+echo "CI: checking obsolete workflow generations are absent"
+for path in \
+  .github/workflows/component-test-deploy-v3.yml \
+  .github/workflows/component-test-deploy-v4.yml \
+  .github/workflows/component-test-deploy-v5.yml \
+  .github/workflows/component-test-rollback-v3.yml \
+  .github/workflows/component-test-rollback-v4.yml \
+  .github/workflows/component-test-rollback-v5.yml
+ do
+  [[ ! -f "$path" ]] || fail "Obsolete workflow still present: $path"
+ done
+
+echo "CI: repo guard checks passed"

--- a/tools/ci/check_shell_syntax_v2.sh
+++ b/tools/ci/check_shell_syntax_v2.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t files < <(find . -type f -name '*.sh' | sort)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "CI: no shell scripts found"
+  exit 0
+fi
+
+for file in "${files[@]}"; do
+  echo "CI: bash -n $file"
+  bash -n "$file"
+done
+
+echo "CI: shell syntax checks passed"


### PR DESCRIPTION
Replaces the first CI attempt with a branch cut from current `main` and checks aligned to the real repo state.

Included:
- `tools/ci/check_repo_guard_v2.sh`
- `tools/ci/check_shell_syntax_v2.sh`
- `.github/workflows/repo-guard-v2.yml`

What changed versus the earlier CI attempt:
- checks run against current `main` state
- required SI/N journal files now exist on the branch base
- placeholder v1 governance docs are no longer hard-failed
- the currently tracked tuner pycache artifact is explicitly grandfathered for now so CI can become usable before the cleanup PR lands
- shell scripts still get `bash -n` validation

Follow-up still needed:
- remove the tracked tuner `__pycache__` artifact from the repository and then tighten the guard further
- consolidate branch doctrine wording into one canonical source
