### PR TITLE
Tighten CI after pycache cleanup

### DIFF
--- a/.github/workflows/repo-health-v3.yml
+++ b/.github/workflows/repo-health-v3.yml
@@ -1,0 +1,31 @@
+name: repo-health-v3
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  repo_guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run repo guard checks
+        shell: bash
+        run: |
+          bash tools/ci/check_repo_guard_v3.sh
+
+  shell_syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run shell syntax checks
+        shell: bash
+        run: |
+          bash tools/ci/check_shell_syntax_v3.sh

--- a/tools/ci/check_repo_guard_v3.sh
+++ b/tools/ci/check_repo_guard_v3.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "CI: $1"; exit 1; }
+
+if find . \( -name '__pycache__' -o -name '*.pyc' \) | grep -q .; then
+  find . \( -name '__pycache__' -o -name '*.pyc' \)
+  fail "Python cache artifacts are not allowed"
+fi
+
+echo "CI: checking required governance and status files"
+for path in \
+  contracts/repo/release_intake_and_delivery_status_v2.md \
+  contracts/repo/component_journal_policy_v2.md \
+  contracts/repo/repository_language_standard_v2.md \
+  journals/system-integration-normalization/STATUS_system_integration_normalization_v1.md \
+  journals/system-integration-normalization/DECISIONS_system_integration_normalization_v1.md \
+  .github/workflows/component-test-deploy-v6.yml \
+  .github/workflows/component-test-rollback-v6.yml
+ do
+  [[ -f "$path" ]] || fail "Missing required file: $path"
+ done
+
+echo "CI: checking obsolete workflow generations are absent"
+for path in \
+  .github/workflows/component-test-deploy-v3.yml \
+  .github/workflows/component-test-deploy-v4.yml \
+  .github/workflows/component-test-deploy-v5.yml \
+  .github/workflows/component-test-rollback-v3.yml \
+  .github/workflows/component-test-rollback-v4.yml \
+  .github/workflows/component-test-rollback-v5.yml
+ do
+  [[ ! -f "$path" ]] || fail "Obsolete workflow still present: $path"
+ done
+
+echo "CI: repo guard checks passed"

--- a/tools/ci/check_shell_syntax_v3.sh
+++ b/tools/ci/check_shell_syntax_v3.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -t files < <(find . -type f -name '*.sh' | sort)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "CI: no shell scripts found"
+  exit 0
+fi
+
+for file in "${files[@]}"; do
+  echo "CI: bash -n $file"
+  bash -n "$file"
+done
+
+echo "CI: shell syntax checks passed"


### PR DESCRIPTION
Follow-up CI tightening after the tracked tuner pycache artifact was removed from `main`.

Included:
- `tools/ci/check_repo_guard_v3.sh`
- `tools/ci/check_shell_syntax_v3.sh`
- `.github/workflows/repo-health-v3.yml`

What changes now:
- Python cache artifacts are fully banned again
- governance and SI/N status files remain required
- obsolete deploy workflow generations remain forbidden
- shell scripts still get `bash -n`

This is the next step after the pycache cleanup and should become the preferred repo guard lane.
