### PR TITLE
Add branch doctrine, artifact model, and naming standards

### DIFF
--- a/contracts/repo/branch_strategy_v2.md
+++ b/contracts/repo/branch_strategy_v2.md
@@ -1,0 +1,78 @@
+# BRANCH STRATEGY V2
+
+Status: canonical branch doctrine for repository operation.
+
+## Leading rule
+The branch follows the **component lifecycle**, not the individual plugin count.
+
+A component may contain multiple deployable artifacts or plugins.
+That does **not** automatically justify separate branches.
+
+## Canonical branch doctrine
+- `main` = truth for workflows, governance, accepted stable artifacts, and operator-visible execution paths.
+- `dev/<component>` = active component work lane.
+- `integration/staging` = optional integration-owned temporary branch kept aligned to `main` when actively used.
+
+`integration/staging` is **not** a second truth branch.
+
+## Persistent branches
+- `main`
+- `integration/staging`
+- `dev/tuner`
+- `dev/bridge`
+- `dev/autoswitch`
+- `dev/fun-line`
+- `dev/starter`
+- `dev/hardware`
+
+## Branch ownership
+### main
+- protected truth branch
+- workflows live here
+- governance lives here
+- accepted stable artifacts live here
+- no uncontrolled direct development
+
+### integration/staging
+- owned by system integration / normalization
+- used for temporary integration packaging, repo-control-plane work, contract alignment, and staging-only integration blocks
+- should be reset or realigned to current `main` when reused
+
+### dev/<component>
+- owned by the relevant specialist lane for that component
+- contains evolving payloads, deploy candidates, docs, and journals for that component
+- should stay at `0 behind main` whenever practical
+
+## One component, multiple artifacts
+A component may ship multiple deployable artifacts with different roles, for example:
+- `runtime`
+- `launcher`
+- `service`
+- `renderer`
+- `source_tile`
+- `bridge`
+- `ui_entry`
+
+These artifacts normally stay on the **same component branch**.
+
+## When to split into separate branches
+Split only when the artifacts have materially different:
+- owners
+- rollout cadence
+- rollback semantics
+- acceptance path
+- deployment contract
+
+If those conditions are not true, keep one branch and document multiple artifact roles inside the component.
+
+## Bridge-specific note
+Bridge is an overlay component.
+Its governance must explicitly describe:
+- overlay ownership / arbitration behavior
+- interaction with other overlays
+- launcher/open-entry artifact if present
+- runtime overlay artifact if present
+- rollback and Volumio unregistration behavior where applicable
+
+## Promotion rule
+Promotion to `main` happens by component block, not by arbitrary single plugin fragment, unless governance explicitly documents an exception.

--- a/contracts/repo/component_artifact_model_v1.md
+++ b/contracts/repo/component_artifact_model_v1.md
@@ -1,0 +1,65 @@
+# COMPONENT ARTIFACT MODEL V1
+
+## Purpose
+This contract defines how one repository component may contain multiple deployable artifacts, plugins, or helper units without fragmenting governance or branch doctrine.
+
+## Leading rule
+A **component** is the functional delivery unit.
+An **artifact** is one deployable or runtime piece inside that component.
+
+Governance, branch ownership, rollout state, and journals default to the **component** level.
+
+## Artifact roles
+A component may contain one or more artifacts with explicit roles, for example:
+- `runtime`
+- `launcher`
+- `service`
+- `renderer`
+- `source_tile`
+- `bridge`
+- `ui_entry`
+- `helper`
+
+## Required artifact fields
+Each component should eventually document, for every artifact:
+- artifact name
+- artifact role
+- implementation type
+- whether it is a Volumio plugin, service, script set, or helper asset
+- whether it is user-visible
+- whether it is required for deployment success
+- whether rollback must unregister it from Volumio
+
+## Default rule for two-plugin patterns
+If a component contains:
+- one plugin/artifact with the effective runtime logic, and
+- one plugin/artifact that exposes the icon, button, source tile, or overlay entry,
+then both artifacts still belong to the **same component** unless explicitly split by governance.
+
+## Branch rule
+One component normally uses one branch:
+- `dev/<component>` for evolving work
+- `main` for accepted truth
+
+Do not create separate branches only because the component has multiple plugins.
+
+## Release rule
+Multiple artifacts that belong to one component should normally move together under one component release number.
+Only split release numbers when governance explicitly records that the artifacts are independently versioned.
+
+## Bridge overlay rule
+Bridge must be treated as a multi-artifact overlay component when applicable.
+Typical Bridge artifacts may include:
+- runtime overlay artifact
+- launcher or open-entry artifact
+- optional helper/runtime coordination files
+
+Bridge component docs and journals should record:
+- overlay ownership semantics
+- interaction with other overlay screens
+- what opens the overlay
+- what actually renders or maintains the overlay
+- rollback and unregistration requirements
+
+## Documentation rule
+Component journals remain at the component level, but they should mention artifact roles whenever those roles matter for deployment, rollback, acceptance, or user-visible behavior.

--- a/contracts/repo/naming_and_release_numbering_standard_v1.md
+++ b/contracts/repo/naming_and_release_numbering_standard_v1.md
@@ -1,0 +1,91 @@
+# NAMING AND RELEASE NUMBERING STANDARD V1
+
+## Purpose
+This contract makes naming and release numbering mandatory and repository-wide.
+
+## Leading rules
+- repository-facing naming is English
+- component names are normalized and stable
+- new governed releases use a predictable numbering model
+- ad-hoc release names are not the default for new normalized work
+
+## Component naming
+Repository component directories must use this form:
+- `components/scale-radio-<component>/`
+
+Examples:
+- `components/scale-radio-bridge/`
+- `components/scale-radio-tuner/`
+- `components/scale-radio-autoswitch/`
+
+Legacy aliases may be recorded in journals or docs, but the normalized repo name remains the canonical name.
+
+## Branch naming
+Use:
+- `main`
+- `integration/staging`
+- `dev/<component>`
+
+Examples:
+- `dev/bridge`
+- `dev/tuner`
+- `dev/fun-line`
+
+## Artifact naming
+When a component contains multiple artifacts, artifact names should reflect the component plus the artifact role.
+
+Preferred pattern inside docs/manifests:
+- `<component>:<artifact_role>`
+
+Examples:
+- `bridge:runtime`
+- `bridge:launcher`
+- `tuner:runtime`
+- `tuner:source_tile`
+
+## Payload directory naming
+### Mutable working payloads
+Use these reserved names only:
+- `current_dev` = current development payload on a component branch
+- `current` = current accepted payload when that is the intentionally maintained pointer
+
+### Immutable numbered releases
+New normalized governed releases should use:
+- `vMAJOR.MINOR.PATCH`
+
+Examples:
+- `v0.1.0`
+- `v1.0.0`
+- `v1.2.3`
+
+## Release numbering model
+Use semantic versioning at the component release level:
+- `MAJOR` = incompatible contract or deployment change
+- `MINOR` = backward-compatible feature or artifact expansion
+- `PATCH` = backward-compatible fix or packaging correction
+
+## Multi-artifact release rule
+If multiple artifacts belong to one component, they normally share the **same component release number**.
+
+Example:
+- `bridge:runtime` and `bridge:launcher` both belong to component release `v1.3.0`
+
+Do not invent separate artifact version lines unless governance explicitly documents that split.
+
+## Historical imports
+Previously imported payload names such as legacy stable tags or descriptive folder names may remain for historical continuity.
+However:
+- they should be marked as historical or pre-normalization where relevant
+- new normalized releases should use the standard numbering model
+
+## Required release handoff fields
+Every governed release handoff should state:
+- component name
+- branch/ref
+- payload path
+- release number or reserved mutable pointer name
+- artifact roles included in that release
+- current lifecycle status
+
+## Enforcement intention
+This naming and release numbering standard should be treated as mandatory governance and should be enforced by CI progressively.


### PR DESCRIPTION
Adds the next governance layer needed before broader development proceeds.

Included:
- `contracts/repo/branch_strategy_v2.md`
- `contracts/repo/component_artifact_model_v1.md`
- `contracts/repo/naming_and_release_numbering_standard_v1.md`

What this fixes:
- makes `main` the clear canonical truth branch in branch doctrine
- keeps `integration/staging` as optional temporary staging, not a second truth branch
- formalizes the rule that one component may ship multiple deployable artifacts/plugins without needing separate branches
- adds explicit Bridge overlay governance language
- makes naming and release numbering mandatory governance
- standardizes mutable payload names and immutable semantic release numbering

Why this matters:
- avoids repeated debates about two-plugin components
- gives Bridge the missing overlay/component-artifact governance treatment
- creates the repo-side basis for future CI enforcement of naming and release standards
