### PR TITLE
Add agent onboarding files and skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# AGENTS.md
+
+## Purpose
+This file provides repository-wide operating instructions for coding agents working in this repo.
+
+## Read first
+Before touching files, read these governance documents on `main`:
+- `contracts/repo/branch_strategy_v2.md`
+- `contracts/repo/component_artifact_model_v1.md`
+- `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- `contracts/repo/release_intake_and_delivery_status_v2.md`
+- `contracts/repo/component_journal_policy_v2.md`
+- `contracts/repo/repository_language_standard_v2.md`
+
+## Core doctrine
+- `main` is the canonical truth branch for workflows, governance, accepted stable artifacts, and operator-visible execution paths.
+- `dev/<component>` is the active component work lane.
+- one component may contain multiple deployable artifacts/plugins
+- do not split branches only because a component has multiple plugins
+- Bridge is an overlay component and must be treated as such in docs, journals, deploy logic, and rollback logic
+
+## Release and naming rules
+- follow `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- mutable payload names are reserved: `current_dev`, `current`
+- new normalized immutable releases should use `vMAJOR.MINOR.PATCH`
+- do not invent new naming patterns without updating governance first
+
+## Documentation and journals
+- repository-facing content is English
+- update journals when deployment reality or component state changes materially
+- prefer factual current-state updates over narrative prose
+
+## Workflow doctrine
+- active deploy workflows live on `main`
+- current supported deploy lane is the v6 generic component workflow family unless newer governance supersedes it
+- do not reintroduce obsolete workflow generations
+
+## CI doctrine
+- keep the repository free of Python cache artifacts
+- do not commit placeholder governance documents for active standards
+- shell scripts should remain syntax-clean under `bash -n`
+
+## Required behavior for agents
+- make repository changes in a dedicated branch
+- keep changes scoped and governance-consistent
+- prefer component-level changes over ad-hoc plugin-fragment changes
+- if a new operational rule is introduced, put it into governance docs instead of relying on chat memory
+
+## Skills and reference docs
+Agents should consult:
+- `docs/agents/skill_volumio4_plugin_development_v1.md`
+- `docs/agents/skill_overlay_component_governance_v1.md`
+- `docs/agents/reference_repositories_and_docs_v1.md`

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Scope
+This file applies to everything under `components/`.
+
+## Component development rules
+- treat each `components/scale-radio-<component>/` directory as one governed component
+- a component may contain multiple artifacts/plugins with different roles
+- default artifact roles include `runtime`, `launcher`, `service`, `renderer`, `source_tile`, `bridge`, `ui_entry`, `helper`
+- keep artifact role language explicit in docs, deploy candidates, and journals
+
+## Volumio 4 plugin expectations
+- align with Volumio 4 / Bookworm realities
+- keep plugin category and runtime role explicit
+- document whether an artifact is a Volumio plugin, service, helper script set, renderer, or overlay entry artifact
+- when rollback applies to a plugin, document whether Volumio unregistration is required
+
+## Overlay-specific rule
+Components that participate in overlay ownership must document:
+- what opens the overlay
+- what renders the overlay
+- whether hidden mode exists
+- whether overlay arbitration/ownership files are used
+- rollback behavior
+
+## Packaging and releases
+- use component-level release numbering by default
+- if multiple artifacts move together, they share the component release number
+- do not create separate version lines for launcher/runtime pairs unless governance explicitly records that split
+
+## Path discipline
+- put payloads under `payload/`
+- put deploy scripts under `deploy_candidates/`
+- do not scatter active release logic across unrelated directories

--- a/docs/agents/reference_repositories_and_docs_v1.md
+++ b/docs/agents/reference_repositories_and_docs_v1.md
@@ -1,0 +1,48 @@
+# REFERENCE REPOSITORIES AND DOCS V1
+
+## Purpose
+This document gives coding agents a curated reference set for Volumio 4 and related overlay/plugin work.
+
+## Primary sources
+### Volumio developer documentation
+Use for:
+- plugin system concepts
+- plugin command-line utility
+- plugin publishing expectations
+- API references
+
+### Volumio GitHub organization
+Use for:
+- upstream code-reading
+- official example structures
+- plugin source references
+
+Important repositories to inspect when relevant:
+- `volumio/volumio-plugins-sources`
+- `volumio/volumio3-backend`
+- `volumio/Volumio2-UI`
+- `volumio/volumio-developers-docs`
+
+## Community/reference repos
+### foonerd repositories
+Use as implementation references for Bookworm-era Peppy and related display/runtime work.
+Relevant repos include:
+- `foonerd/peppy_screensaver`
+- `foonerd/peppy_builds`
+- `foonerd/peppy_remote`
+- `foonerd/peppy_templates`
+
+These are reference inputs, not automatic truth. Community repos may have support or maintenance limits.
+
+## Reference usage rules
+- prefer official Volumio docs for standards and APIs
+- use community repos to study patterns, runtime behavior, and compatibility workarounds
+- do not assume community code is store-ready or officially supported
+- document when repo code intentionally depends on community-maintained behavior
+
+## Current repository expectation
+When in doubt:
+1. read governance docs first
+2. consult official Volumio docs second
+3. consult reference repos third
+4. encode repo decisions back into governance or journals when they become operational rules

--- a/docs/agents/skill_overlay_component_governance_v1.md
+++ b/docs/agents/skill_overlay_component_governance_v1.md
@@ -1,0 +1,33 @@
+# SKILL — OVERLAY COMPONENT GOVERNANCE V1
+
+## Purpose
+This skill helps agents work on components that share display/runtime space with other overlays.
+
+## Leading rule
+Treat overlay behavior as governance-critical, not just UI detail.
+
+## Required overlay questions
+- what opens the overlay?
+- what renders or maintains the overlay?
+- is there a separate launcher artifact?
+- is there a separate runtime artifact?
+- what file or state indicates active overlay control?
+- what happens when another overlay becomes active?
+- what is the hidden or deep-idle behavior?
+- what must rollback remove or unregister?
+
+## Bridge-specific note
+Bridge is already governed as an overlay component.
+Any Bridge change should preserve:
+- clean-replace deployment semantics
+- repo-driven deployment
+- rollback plus Volumio unregistration when applicable
+- explicit overlay-control documentation
+
+## Documentation expectations
+Overlay components should document:
+- launcher artifact role
+- runtime artifact role
+- overlay-control behavior
+- visible vs hidden behavior
+- known interaction with other overlays

--- a/docs/agents/skill_volumio4_plugin_development_v1.md
+++ b/docs/agents/skill_volumio4_plugin_development_v1.md
@@ -1,0 +1,40 @@
+# SKILL — VOLUMIO 4 PLUGIN DEVELOPMENT V1
+
+## Purpose
+This skill gives coding agents a stable starting point for Volumio 4 plugin work in this repository.
+
+## Read before coding
+- `AGENTS.md`
+- `components/AGENTS.md`
+- `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- `contracts/repo/component_artifact_model_v1.md`
+
+## Working assumptions
+- target platform is Volumio 4 on Bookworm
+- repository code should reflect actual Volumio plugin/runtime behavior, not guesswork
+- plugin role should be explicit: source tile, user-interface plugin, helper service, overlay launcher, runtime renderer, hardware support, or similar
+
+## Required questions the agent must answer in docs/journals
+- what Volumio plugin category or runtime role does this artifact belong to?
+- is it user-visible?
+- does it open a screen, render a screen, provide a source tile, or run in the background?
+- what install path is used?
+- what rollback path is required?
+- must Volumio unregistration happen on rollback?
+
+## Preferred development pattern
+1. identify the component
+2. identify the artifact role(s)
+3. map the payload path
+4. map deploy candidate scripts
+5. map rollback/unregistration expectations
+6. update current-state docs if operational reality changes
+
+## Volumio-specific expectations
+- keep category and lifecycle explicit
+- do not assume store-ready quality from imported payloads
+- prefer repo-driven deploy/rollback semantics over Pi-local bootstrap assumptions
+- keep plugin activation behavior and runtime side effects documented
+
+## Repository references
+Use the official Volumio developer docs and the reference repos listed in `docs/agents/reference_repositories_and_docs_v1.md`.


### PR DESCRIPTION
Adds initial agent-onboarding material for this repository.

Included:
- `AGENTS.md`
- `components/AGENTS.md`
- `docs/agents/skill_volumio4_plugin_development_v1.md`
- `docs/agents/skill_overlay_component_governance_v1.md`
- `docs/agents/reference_repositories_and_docs_v1.md`

What this does:
- gives coding agents a repo-wide operating file using the AGENTS.md model
- scopes component-specific rules under `components/`
- links agent work to existing governance doctrine
- defines a Volumio 4 plugin-development skill
- defines an overlay-component governance skill
- gives agents a curated reference set covering official Volumio docs, Volumio upstream repos, and foonerd reference repos

Why this matters:
- reduces repeated context rebuilding
- makes Codex/agent onboarding explicit inside the repo
- gives future CI and governance work a stable agent-facing entrypoint
