### PR TITLE
Add canonical governance source and overlay contract docs

### DIFF
--- a/contracts/repo/canonical_governance_sources_v1.md
+++ b/contracts/repo/canonical_governance_sources_v1.md
@@ -1,0 +1,49 @@
+# CANONICAL GOVERNANCE SOURCES V1
+
+## Purpose
+This document defines source precedence when multiple governance documents exist in the repository.
+
+## Leading rule
+If two repository governance documents overlap or appear inconsistent, use the higher-precedence document listed here.
+
+## Precedence order
+### 1. Canonical branch and component doctrine
+- `contracts/repo/branch_strategy_v2.md`
+- `contracts/repo/component_artifact_model_v1.md`
+- `contracts/repo/overlay_component_contract_v1.md`
+
+These define:
+- what `main` means
+- what `dev/<component>` means
+- what `integration/staging` means
+- how one component may contain multiple deployable artifacts/plugins
+- how overlay components such as Bridge must be governed
+
+### 2. Naming and release doctrine
+- `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- `contracts/repo/release_intake_and_delivery_status_v2.md`
+
+These define:
+- naming rules
+- release numbering rules
+- payload naming rules
+- lifecycle status and promotion rules
+
+### 3. Journal and language doctrine
+- `contracts/repo/component_journal_policy_v2.md`
+- `contracts/repo/repository_language_standard_v2.md`
+
+### 4. Agent-facing operational files
+- `AGENTS.md`
+- `components/AGENTS.md`
+- `docs/agents/*`
+
+## Interpretation rule
+Older or superseded files may remain in the repository for history or transition support.
+They must not override the documents listed above.
+
+## Specific conflict resolution
+- If `branch_strategy_v1.md` and `branch_strategy_v2.md` differ, `branch_strategy_v2.md` wins.
+- If any older branch wording implies that `integration/staging` is a second truth branch, this document and `branch_strategy_v2.md` override it.
+- If a component has multiple plugins/artifacts and an older document is ambiguous, `component_artifact_model_v1.md` wins.
+- If a naming or release numbering question is open, `naming_and_release_numbering_standard_v1.md` wins unless a newer canonical replacement exists.

--- a/contracts/repo/overlay_component_contract_v1.md
+++ b/contracts/repo/overlay_component_contract_v1.md
@@ -1,0 +1,58 @@
+# OVERLAY COMPONENT CONTRACT V1
+
+## Purpose
+This contract defines repository governance requirements for components that open, render, or arbitrate overlays.
+
+## Leading rule
+Overlay behavior is a governed runtime contract, not only a UI detail.
+
+## Applies to
+Any component that:
+- opens an overlay
+- renders an overlay
+- shares visible display/runtime space with another overlay
+- participates in overlay ownership or arbitration
+- can force another overlay into hidden or idle behavior
+
+## Required overlay fields
+Every governed overlay component should document:
+- component name
+- artifact roles involved
+- which artifact opens the overlay
+- which artifact renders or maintains the overlay
+- whether overlay ownership or arbitration is used
+- what file, state, or process indicates active overlay control
+- visible behavior
+- hidden behavior
+- deep-idle behavior, if any
+- rollback behavior
+- Volumio unregistration behavior, if applicable
+
+## Artifact role pattern
+Overlay components may include multiple artifacts, for example:
+- `launcher`
+- `runtime`
+- `bridge`
+- `renderer`
+- `helper`
+
+These remain one governed component unless explicitly split by governance.
+
+## Deployment rule
+Overlay deployment must preserve:
+- clean-replace semantics
+- explicit rollback path
+- documented interaction with existing overlay state
+
+## Rollback rule
+Rollback must restore a stable operator-visible state.
+If the overlay component includes a Volumio plugin artifact, rollback must also document whether plugin unregistration is required.
+
+## Bridge note
+Bridge is explicitly governed under this overlay contract.
+Bridge documentation and journals must state:
+- runtime overlay artifact
+- launcher/open-entry artifact, if present
+- how overlay control is established
+- known interaction with other overlays
+- accepted temporary activation quirks, if any

--- a/contracts/repo/superseded_documents_index_v1.md
+++ b/contracts/repo/superseded_documents_index_v1.md
@@ -1,0 +1,29 @@
+# SUPERSEDED DOCUMENTS INDEX V1
+
+## Purpose
+This document records older governance files that should remain readable for history but no longer control repository interpretation.
+
+## Superseded or lower-precedence documents
+### Branch doctrine
+- `contracts/repo/branch_strategy_v1.md`
+  - superseded by `contracts/repo/branch_strategy_v2.md`
+
+### Placeholder-era governance files
+The following may still exist for transition reasons or historical continuity, but they do not override the active standards:
+- `contracts/repo/release_intake_and_delivery_status_v1.md`
+- `contracts/repo/component_journal_policy_v1.md`
+- `contracts/repo/repository_language_standard_v1.md`
+
+### Interpretation rule
+If an older file conflicts with:
+- `contracts/repo/canonical_governance_sources_v1.md`
+- `contracts/repo/branch_strategy_v2.md`
+- `contracts/repo/component_artifact_model_v1.md`
+- `contracts/repo/overlay_component_contract_v1.md`
+- `contracts/repo/naming_and_release_numbering_standard_v1.md`
+
+then the newer canonical source wins.
+
+## Cleanup intention
+Historical or superseded files may be replaced with explicit superseded stubs later.
+Until then, this index defines their standing.


### PR DESCRIPTION
Adds the next governance cleanup layer to reduce doctrine ambiguity without deleting historical files yet.

Included:
- `contracts/repo/canonical_governance_sources_v1.md`
- `contracts/repo/overlay_component_contract_v1.md`
- `contracts/repo/superseded_documents_index_v1.md`

What this does:
- defines explicit governance source precedence
- makes `branch_strategy_v2.md` the clear winner over older branch wording
- adds a dedicated overlay-component contract
- gives Bridge a formal overlay-governance home inside contracts
- records that placeholder-era and older governance files are lower-precedence during transition

Why this matters:
- reduces branch-doctrine ambiguity across docs
- prevents repeated debate over overlay behavior and multi-artifact components
- creates a cleaner basis for future CI enforcement and document cleanup
