### PR TITLE
Add initial component current-state and stream journals

### DIFF
--- a/journals/scale-radio-autoswitch/current_state_v1.md
+++ b/journals/scale-radio-autoswitch/current_state_v1.md
@@ -1,0 +1,43 @@
+# CURRENT STATE — scale-radio-autoswitch
+
+## Component
+- normalized component name: `scale-radio-autoswitch`
+- governed role: analog-input signal detection and tape-monitor style source switching helper
+- active work lane: `dev/autoswitch`
+
+## Repo truth
+- component branch `dev/autoswitch` exists
+- legacy handover already provides concrete script/service mapping into component paths
+- component is runtime-validated enough to document clearly, but still not integrated enough for `main` truth
+
+## Lifecycle status
+- `payload_complete`
+- `functional_acceptance_open`
+
+## Accepted runtime posture
+- ALSA amplitude detection via `arecord + sox`
+- VINL1 / VINR1 routing on HiFiBerry DAC+ ADC Pro
+- authoritative runtime entrypoint: `revox-autoswitch.service`
+- asymmetric debounce:
+  - engage fast
+  - disengage slower
+
+## Current known working behavior
+- amplitude polling logic works
+- threshold-based switching logic works with the `0.02` baseline
+- systemd auto-restart behavior exists
+- manual toggle fallback script exists
+- component explicitly avoids `mpd.conf` injection and abandons the old loopback strategy
+
+## Current gaps
+- previous playback source restore is unresolved
+- renderer-visible tape-state export is unresolved
+- interaction with future overlay ownership signaling remains unresolved
+- long-duration runtime validation is still open
+- branch should remain dev-only for now
+
+## Repo-normalized next action
+1. add a simple exported tape-active state visible to renderer/overlay consumers
+2. decide whether source restore belongs here or in a source-engine layer
+3. add card-index detection fallback if needed
+4. only after that consider promotion beyond the dev lane

--- a/journals/scale-radio-autoswitch/stream_v1.md
+++ b/journals/scale-radio-autoswitch/stream_v1.md
@@ -1,0 +1,7 @@
+# STREAM — scale-radio-autoswitch
+
+- 2026-04-13: Initial repo journal created from legacy autoswitch status and decision handover.
+- 2026-04-13: ALSA amplitude detection via `arecord + sox` recorded as the locked runtime architecture.
+- 2026-04-13: VINL1/VINR1 routing and `revox-autoswitch.service` recorded as authoritative runtime behavior.
+- 2026-04-13: `mpd.conf` injection and `snd-aloop` loopback strategies recorded as superseded/abandoned.
+- 2026-04-13: Component remains dev-only because source-restore and renderer-state integration are still unresolved.

--- a/journals/scale-radio-bridge/current_state_v1.md
+++ b/journals/scale-radio-bridge/current_state_v1.md
@@ -1,0 +1,43 @@
+# CURRENT STATE — scale-radio-bridge
+
+## Component
+- normalized component name: `scale-radio-bridge`
+- primary payload/plugin identity: `radioscale_overlay_bridge`
+- governed artifact role: provider-layer overlay component with bridge/runtime behavior
+- current work lane: `dev/bridge`
+
+## Repo truth
+- component root exists at `components/scale-radio-bridge/`
+- dedicated branch `dev/bridge` exists and is the active component work lane
+- this component already has the most mature repo-driven deploy/rollback lane in the repository
+
+## Lifecycle status
+- `payload_complete`
+- `deployment_candidate_started`
+- `deploy_ready`
+- `tested_on_pi`
+- `functional_acceptance_open`
+
+## Accepted baselines
+- rollback anchor: `rsob_022sf22l.zip`
+- conservative current dev continuation: `radioscale_overlay_bridge_0.2.3_db_cache_r1.zip`
+- authoritative provider posture: LRCLIB lyrics provider, conservative Spotify behavior, additive SQLite sidecar only
+
+## Current known working behavior
+- installable Volumio plugin artifact exists and runs as `radioscale_overlay_bridge`
+- Spotify PKCE callback flow exists
+- Spotify hard backoff is part of the accepted behavior and must be preserved
+- fixed 4-playlist model remains the active architecture
+- repo-driven deploy and rollback lane has already been validated through the generic workflow family on the Pi
+
+## Current gaps
+- lyrics sync quality is still the main unresolved functional weakness
+- long-run validation of `bridge_cache.sqlite` and cache reuse is still pending
+- broader Spotify redesign remains intentionally frozen pending credential/API-key clarification
+- current branch remains a dev lane and is not yet promoted as the accepted `main` artifact truth
+
+## Repo-normalized next action
+1. keep `rsob_022sf22l.zip` documented as rollback anchor
+2. validate `bridge_cache.sqlite` creation and reuse on target Pi
+3. decide whether `0.2.3_db_cache_r1` becomes the next locked stable baseline
+4. keep provider-layer scope intact and avoid renderer/controller drift

--- a/journals/scale-radio-bridge/stream_v1.md
+++ b/journals/scale-radio-bridge/stream_v1.md
@@ -1,0 +1,8 @@
+# STREAM — scale-radio-bridge
+
+- 2026-04-13: Initial repo journal created from legacy bridge status and decision handover.
+- 2026-04-13: Component normalized as provider-layer bridge logic, not renderer/controller ownership.
+- 2026-04-13: Rollback anchor recorded as `rsob_022sf22l.zip`.
+- 2026-04-13: Conservative dev continuation recorded as `radioscale_overlay_bridge_0.2.3_db_cache_r1.zip`.
+- 2026-04-13: Repo truth recorded that `dev/bridge` is the active work lane and that bridge currently has the most mature repo-driven deploy/rollback lane.
+- 2026-04-13: Next required decision remains whether the DB-cache branch becomes the next locked stable baseline.

--- a/journals/scale-radio-fun-line/current_state_v1.md
+++ b/journals/scale-radio-fun-line/current_state_v1.md
@@ -1,0 +1,40 @@
+# CURRENT STATE — scale-radio-fun-line
+
+## Component
+- normalized component name: `scale-radio-fun-line`
+- governed role: overlay / experience-layer component
+- governed artifact pattern: runtime overlay plus source/open-entry pattern, with future visual packs possible
+- active work lane: `dev/fun-line`
+
+## Repo truth
+- dedicated branch `dev/fun-line` exists
+- legacy handover confirms the runtime baseline and decision set strongly, but repo payload normalization remains incomplete and should be treated as an active normalization task
+- this component should remain dev-only for now
+
+## Lifecycle status
+- `payload_partial`
+- `functional_acceptance_open`
+
+## Accepted baseline
+- authoritative runtime baseline: `0.4.2`
+- Dog Line is the first production actor to carry forward
+
+## Current known working behavior
+- browser tile open works on the validated baseline
+- GPIO / encoder open-close path works on the validated baseline
+- radio playback remains stable while Fun Linea opens on the validated baseline
+- overlay coordination with Radio Scale was validated enough to escape the earlier audio slowdown/conflict state
+- open/close public hooks are part of the locked integration contract
+
+## Current gaps
+- later 0.5.0 and 0.6.0 lines are not authoritative runtime baselines
+- config pages repeatedly failed and remain non-authoritative
+- importer/catalog workflow must be treated as unvalidated/non-working
+- exact repo-normalized payload paths for overlay/source/packs remain unresolved
+- component must remain carefully coordinated with tuner so two heavy active renderers are never running simultaneously
+
+## Repo-normalized next action
+1. normalize repo truth around `0.4.2` only
+2. mark later 0.5.0 and 0.6.0 lines as nonleading/partial in repo docs
+3. preserve existing encoder/GPIO open-close hooks unchanged
+4. reintroduce only one production visual pass first: Dog Line

--- a/journals/scale-radio-fun-line/stream_v1.md
+++ b/journals/scale-radio-fun-line/stream_v1.md
@@ -1,0 +1,8 @@
+# STREAM — scale-radio-fun-line
+
+- 2026-04-13: Initial repo journal created from legacy fun-line status and decision handover.
+- 2026-04-13: Fun Line normalized as an overlay / experience-layer component, not a core renderer or ownership-master component.
+- 2026-04-13: `0.4.2` recorded as the only authoritative runtime baseline.
+- 2026-04-13: Hard coordination rule recorded: Fun Line and Radio Scale must not run as two heavy active renderers at the same time.
+- 2026-04-13: Dog Line recorded as the first production actor to carry forward.
+- 2026-04-13: Repo payload normalization and config/importer revalidation remain open tasks.

--- a/journals/scale-radio-hardware/current_state_v1.md
+++ b/journals/scale-radio-hardware/current_state_v1.md
@@ -1,0 +1,46 @@
+# CURRENT STATE — scale-radio-hardware
+
+## Component
+- normalized component name: `scale-radio-hardware`
+- governed role: donor-hardware integration and standalone hardware validation lane
+- active work lane: `dev/hardware`
+
+## Repo truth
+- dedicated branch `dev/hardware` exists
+- legacy handover provides strong scope and decision truth, but repo source normalization is still incomplete and should remain on the dev lane
+- component is not mature enough for `main`
+
+## Lifecycle status
+- `payload_partial`
+- `functional_acceptance_open`
+
+## Accepted hardware posture
+- retained donor parts in phase 1:
+  - original SABA MT201 tuning knob
+  - shaft
+  - flywheel
+- phase-1 sensing baseline:
+  - AS5600 magnetic angle sensor
+  - I2C-first test path
+  - HiFiBerry-safe wiring discipline
+- standalone Volumio validation plugin is required so the sensor path can be tested independently of Radio Scale runtime
+
+## Current known working behavior
+- phase-1 reuse scope is clarified and locked
+- AS5600 is the selected phase-1 sensor baseline
+- magnet requirement and orientation/calibration posture are clarified
+- safe initial wiring rules for Pi 4B + HiFiBerry DAC+ ADC Pro were defined
+- standalone hardware validation lane concept already exists
+
+## Current gaps
+- no confirmed repo-integrated Pi-validated baseline yet
+- no confirmed production-ready install/rollback path in repo yet
+- live AS5600 communication on target Pi remains unvalidated
+- mechanical bracket/adapter dimensions remain open until real measurements are captured
+- preset-button reuse remains open
+
+## Repo-normalized next action
+1. keep this component on `dev/hardware`
+2. normalize source-of-truth under `components/scale-radio-hardware/`
+3. commit the standalone AS5600 tester as source, not only as generated artifact
+4. validate I2C communication and live angle reading on the target Pi

--- a/journals/scale-radio-hardware/stream_v1.md
+++ b/journals/scale-radio-hardware/stream_v1.md
@@ -1,0 +1,8 @@
+# STREAM — scale-radio-hardware
+
+- 2026-04-13: Initial repo journal created from legacy hardware status and decision handover.
+- 2026-04-13: Component normalized as donor-hardware integration plus standalone hardware-validation lane.
+- 2026-04-13: Phase-1 retained-hardware rule recorded: original SABA MT201 knob, shaft, and flywheel stay.
+- 2026-04-13: AS5600 recorded as the phase-1 sensor baseline with I2C-first, HiFiBerry-safe wiring discipline.
+- 2026-04-13: Standalone Volumio validation plugin requirement recorded as a locked hardware-track rule.
+- 2026-04-13: Component remains dev-only pending repo source normalization and target-Pi validation.

--- a/journals/scale-radio-starter/current_state_v1.md
+++ b/journals/scale-radio-starter/current_state_v1.md
@@ -1,0 +1,41 @@
+# CURRENT STATE — scale-radio-starter
+
+## Component
+- normalized component name: `scale-radio-starter`
+- governed role: startup/runtime glue and boot-handover component
+- active baseline class: accepted stable starter line plus archived experiment lines
+- repo work lane: `dev/starter` exists; accepted baseline is conceptually main-truth-ready but repo mapping still needs stricter normalization
+
+## Repo truth
+- dedicated branch `dev/starter` exists
+- starter legacy handover confirms a stable accepted baseline, but repository path/payload mapping is still not cleanly grounded from the surviving chat context
+- this component currently needs journal truth more than new architecture work
+
+## Lifecycle status
+- `payload_partial`
+- `functional_acceptance_open`
+
+## Accepted baseline
+- `mediastreamer_bootdelay_fix_v0.1.0`
+- `mediastreamer_hybrid_startup_standby_v0.2.2_stable`
+- stable target preference:
+  - `http://127.0.0.1:4004/` first
+  - `http://127.0.0.1:3000/` fallback
+
+## Current known working behavior
+- `bootdelay=0` on the accepted line
+- hybrid runtime starts through a `volumio-kiosk` drop-in and hybrid wrapper
+- `mediastreamer-shellctl standby`, `wake`, and `status` are the authoritative runtime controls
+- stable line is functionally accepted even if startup visuals are not yet appliance-grade
+
+## Current gaps
+- exact repo component-path and payload normalization still need confirmation against Git truth
+- exact stable asset inventory for `v0.2.2 stable` remains uncertain in the surviving context
+- later appliance/direct-now-playing lines are explicitly nonleading and should remain archived/experimental only
+- deep idle, FPS cap, and render-throttling must remain unresolved here unless grounded by another specialist lane
+
+## Repo-normalized next action
+1. re-ground the actual starter payload/source tree in the repository
+2. preserve `v0.1.0 + v0.2.2 stable` as the only active baseline
+3. keep later startup variants archived as nonleading
+4. avoid claiming performance/runtime truths from this lane that were not actually validated here

--- a/journals/scale-radio-starter/stream_v1.md
+++ b/journals/scale-radio-starter/stream_v1.md
@@ -1,0 +1,8 @@
+# STREAM — scale-radio-starter
+
+- 2026-04-13: Initial repo journal created from legacy starter status and decision handover.
+- 2026-04-13: Accepted starter baseline recorded as `mediastreamer_bootdelay_fix_v0.1.0` plus `mediastreamer_hybrid_startup_standby_v0.2.2_stable`.
+- 2026-04-13: Preferred handover target order recorded as `4004` first and `3000` fallback.
+- 2026-04-13: `mediastreamer-shellctl standby|wake|status` recorded as the authoritative runtime control interface.
+- 2026-04-13: Later appliance/direct-now-playing lines recorded as nonleading experiment history only.
+- 2026-04-13: Repo-path and payload normalization still marked unresolved and must be re-grounded against actual Git truth.

--- a/journals/scale-radio-tuner/stream_v1.md
+++ b/journals/scale-radio-tuner/stream_v1.md
@@ -1,0 +1,8 @@
+# STREAM — scale-radio-tuner
+
+- 2026-04-13: Initial repo journal created from legacy tuner status and decision handover.
+- 2026-04-13: Tuner normalized as one component with multiple artifacts: overlay, source, and resident renderer service.
+- 2026-04-13: Authoritative tuner baseline recorded as the resident-renderer lineage culminating in `1.10.2`.
+- 2026-04-13: Locked public method contract and fixed `scale_fm_renderer.service` naming carried into repo truth.
+- 2026-04-13: Shared overlay-owner handling via `/tmp/mediastreamer_active_overlay.json` recorded as governed behavior.
+- 2026-04-13: Remaining gaps recorded as runtime validation, first-show pointer sweep, exit white flashes, pointer jitter, and incomplete OE1 cleanup.


### PR DESCRIPTION
Adds the first real repo-side component journals based on current governance plus the uploaded legacy handovers.

Included journals:
- `journals/scale-radio-bridge/current_state_v1.md`
- `journals/scale-radio-bridge/stream_v1.md`
- `journals/scale-radio-tuner/current_state_v1.md`
- `journals/scale-radio-tuner/stream_v1.md`
- `journals/scale-radio-starter/current_state_v1.md`
- `journals/scale-radio-starter/stream_v1.md`
- `journals/scale-radio-autoswitch/current_state_v1.md`
- `journals/scale-radio-autoswitch/stream_v1.md`
- `journals/scale-radio-fun-line/current_state_v1.md`
- `journals/scale-radio-fun-line/stream_v1.md`
- `journals/scale-radio-hardware/current_state_v1.md`
- `journals/scale-radio-hardware/stream_v1.md`

What this does:
- turns the legacy specialist handovers into repo-native journal truth
- records the accepted runtime baselines for bridge, tuner, starter, fun-line, autoswitch, and hardware
- records which components still have repo-path/payload uncertainty and keeps those uncertainties explicit instead of inventing false certainty
- creates the base needed for the next CI step that requires current-state and stream files for active components

Important note:
These journals intentionally normalize against both repo truth and legacy-handovers. Where the legacy handovers were uncertain about repo paths or baseline maturity, the journal keeps that uncertainty explicit.
