### PR TITLE
Replace stub component READMEs with component overviews

### DIFF
--- a/components/scale-radio-autoswitch/README.md
+++ b/components/scale-radio-autoswitch/README.md
@@ -1,3 +1,24 @@
-# Component Root
+# Scale Radio AutoSwitch
 
-This path is reserved for this component.
+## Purpose
+Scale Radio AutoSwitch monitors analog input level and performs tape-monitor style switching behavior for the HiFiBerry DAC+ ADC Pro path.
+
+## Current role
+- governed component: `scale-radio-autoswitch`
+- current work lane: `dev/autoswitch`
+- authoritative runtime entrypoint: `revox-autoswitch.service`
+- active detection model: ALSA amplitude polling via `arecord + sox`
+
+## Boundaries
+This component owns signal detection, ADC routing, and service-driven switching behavior.
+It does not own renderer visuals, source-tile UX, or MPD configuration rewriting.
+
+## Current focus
+- preserve the ALSA polling architecture
+- keep VINL1 / VINR1 routing as the approved mixer path
+- add renderer-visible tape-state export
+- decide ownership for previous-source restore behavior
+
+## See also
+- `journals/scale-radio-autoswitch/current_state_v1.md`
+- `journals/scale-radio-autoswitch/stream_v1.md`

--- a/components/scale-radio-bridge/README.md
+++ b/components/scale-radio-bridge/README.md
@@ -1,3 +1,26 @@
-# Component Root
+# Scale Radio Bridge
 
-This path is reserved for this component.
+## Purpose
+Scale Radio Bridge is the provider-layer bridge for metadata enrichment, lyrics lookup, Spotify track matching, playlist add, and persistent cache behavior.
+
+## Current role
+- governed component: `scale-radio-bridge`
+- current work lane: `dev/bridge`
+- plugin/runtime identity: `radioscale_overlay_bridge`
+- rollback anchor: `rsob_022sf22l.zip`
+- conservative current dev branch baseline: `radioscale_overlay_bridge_0.2.3_db_cache_r1.zip`
+
+## Boundaries
+This component is a provider/bridge layer.
+It does not own renderer layout, global controller logic, or overall overlay ownership.
+
+## Current focus
+- preserve the accepted rollback anchor
+- validate the SQLite sidecar/cache branch on target Pi
+- keep Spotify behavior conservative and preserve the hard backoff logic
+- improve lyrics-sync quality without broad architectural drift
+
+## See also
+- `journals/scale-radio-bridge/current_state_v1.md`
+- `journals/scale-radio-bridge/stream_v1.md`
+- `contracts/repo/overlay_component_contract_v1.md`

--- a/components/scale-radio-fun-line/README.md
+++ b/components/scale-radio-fun-line/README.md
@@ -1,3 +1,25 @@
-# Component Root
+# Scale Radio Fun Line
 
-This path is reserved for this component.
+## Purpose
+Scale Radio Fun Line is the non-core overlay / experience-layer component for fun-mode visuals over the existing MediaStreamer / Volumio runtime.
+
+## Current role
+- governed component: `scale-radio-fun-line`
+- current work lane: `dev/fun-line`
+- authoritative runtime baseline: `0.4.2`
+- first production actor to carry forward: Dog Line
+
+## Boundaries
+This component is an overlay / experience layer.
+It is not a core renderer, playback engine, or ownership-master component.
+
+## Current focus
+- preserve the `0.4.2` runtime baseline
+- keep open/close/encoder/GPIO hooks stable
+- avoid two simultaneously heavy active renderers with Radio Scale
+- reintroduce only one production visual pass first: Dog Line
+
+## See also
+- `journals/scale-radio-fun-line/current_state_v1.md`
+- `journals/scale-radio-fun-line/stream_v1.md`
+- `contracts/repo/overlay_component_contract_v1.md`

--- a/components/scale-radio-hardware/README.md
+++ b/components/scale-radio-hardware/README.md
@@ -1,0 +1,24 @@
+# Scale Radio Hardware
+
+## Purpose
+Scale Radio Hardware governs the donor-hardware integration track, especially retained SABA MT201 controls and the standalone hardware-validation lane for magnetic angle sensing.
+
+## Current role
+- governed component: `scale-radio-hardware`
+- current work lane: `dev/hardware`
+- phase-1 retained parts: knob, shaft, flywheel
+- phase-1 sensor baseline: AS5600 over I2C
+
+## Boundaries
+This component owns donor-hardware reuse, sensor validation, and hardware-facing documentation.
+It does not own the radio-scale renderer, source logic, or final frontpanel-engine production integration.
+
+## Current focus
+- normalize source-of-truth under `components/scale-radio-hardware/`
+- keep the AS5600 tester as a standalone validation lane
+- preserve HiFiBerry-safe wiring discipline
+- validate live angle reading on the target Pi before broader integration
+
+## See also
+- `journals/scale-radio-hardware/current_state_v1.md`
+- `journals/scale-radio-hardware/stream_v1.md`

--- a/components/scale-radio-starter/README.md
+++ b/components/scale-radio-starter/README.md
@@ -1,3 +1,25 @@
 # Scale Radio Starter
 
-This path is reserved for the startup and appliance runtime baseline.
+## Purpose
+Scale Radio Starter governs the accepted startup/runtime glue baseline for MediaStreamer on top of the existing Volumio / touch_display / kiosk stack.
+
+## Current role
+- governed component: `scale-radio-starter`
+- current work lane: `dev/starter`
+- accepted stable baseline:
+  - `mediastreamer_bootdelay_fix_v0.1.0`
+  - `mediastreamer_hybrid_startup_standby_v0.2.2_stable`
+
+## Boundaries
+This component owns startup glue, boot handover, and the accepted hybrid runtime control surface.
+It does not own final appliance-grade startup visuals or imply that deep-idle / FPS-cap / render-throttling are already solved here.
+
+## Current focus
+- preserve the accepted stable baseline
+- keep `4004` as preferred handover target and `3000` as fallback
+- keep `mediastreamer-shellctl standby|wake|status` as the runtime control contract
+- archive later appliance/direct-now-playing variants as nonleading experiments only
+
+## See also
+- `journals/scale-radio-starter/current_state_v1.md`
+- `journals/scale-radio-starter/stream_v1.md`

--- a/components/scale-radio-tuner/README.md
+++ b/components/scale-radio-tuner/README.md
@@ -1,3 +1,28 @@
-# Component Root
+# Scale Radio Tuner
 
-This path is reserved for this component.
+## Purpose
+Scale Radio Tuner is the governed radio-scale experience component for Volumio, including the tuner overlay, source-entry artifact, and resident renderer service.
+
+## Current role
+- governed component: `scale-radio-tuner`
+- current work lane: `dev/tuner`
+- active artifacts:
+  - `Scale FM Overlay`
+  - `Scale FM Source`
+  - `scale_fm_renderer.service`
+- current authoritative baseline: `1.10.2`
+
+## Boundaries
+This component owns the tuner-visible experience and its source-entry/runtime path.
+It does not own Fun Line itself, autoswitch logic, or broader frontpanel-engine scope.
+
+## Current focus
+- validate the `1.10.2` baseline on target Pi
+- preserve the fixed public method contract and service name
+- verify deep-idle and owner-arbitration behavior
+- reduce first-show pointer sweep, exit white flashes, and pointer jitter
+
+## See also
+- `journals/scale-radio-tuner/current_state_v1.md`
+- `journals/scale-radio-tuner/stream_v1.md`
+- `contracts/repo/component_artifact_model_v1.md`


### PR DESCRIPTION
Replaces placeholder/stub component README files with short governed component overviews.

Updated components:
- `components/scale-radio-bridge/README.md`
- `components/scale-radio-tuner/README.md`
- `components/scale-radio-autoswitch/README.md`
- `components/scale-radio-fun-line/README.md`
- `components/scale-radio-hardware/README.md`
- `components/scale-radio-starter/README.md`

What this does:
- removes the remaining “reserved path” style placeholders from active components
- gives each component a short purpose/boundary/current-focus overview
- links each component root to its repo-native current-state and stream journals
- keeps wording aligned with the new branch/artifact/overlay governance layer

Why this matters:
- improves component onboarding for humans and agents
- reduces ambiguity about current baselines and active work lanes
- prepares the repo for the next CI step that forbids stub README content in active components
