### PR TITLE
Add CI for active component journals and READMEs

### DIFF
--- a/.github/workflows/component-health-v1.yml
+++ b/.github/workflows/component-health-v1.yml
@@ -1,0 +1,19 @@
+name: component-health-v1
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  active_component_hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check active components
+        shell: bash
+        run: |
+          bash tools/ci/check_active_components_v1.sh

--- a/tools/ci/check_active_components_v1.sh
+++ b/tools/ci/check_active_components_v1.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() { echo "CI: $1"; exit 1; }
+
+components=(
+  scale-radio-bridge
+  scale-radio-tuner
+  scale-radio-starter
+  scale-radio-autoswitch
+  scale-radio-fun-line
+  scale-radio-hardware
+)
+
+for component in "${components[@]}"; do
+  readme="components/${component}/README.md"
+  current_state="journals/${component}/current_state_v1.md"
+  stream="journals/${component}/stream_v1.md"
+
+  [[ -f "$readme" ]] || fail "Missing component README: $readme"
+  [[ -f "$current_state" ]] || fail "Missing component current-state journal: $current_state"
+  [[ -f "$stream" ]] || fail "Missing component stream journal: $stream"
+
+  if grep -Eiq 'reserved path|^# Component Root$|placeholder|This path is reserved' "$readme"; then
+    fail "Stub/placeholder README detected: $readme"
+  fi
+
+done
+
+echo "CI: active component hygiene checks passed"


### PR DESCRIPTION
Adds the next repo-hardening CI gate for active components.

Included:
- `tools/ci/check_active_components_v1.sh`
- `.github/workflows/component-health-v1.yml`

What it enforces:
- each active component has a component README
- each active component has `current_state_v1.md`
- each active component has `stream_v1.md`
- active component READMEs are no longer allowed to contain reserved-path / placeholder stub text

Active components covered now:
- scale-radio-bridge
- scale-radio-tuner
- scale-radio-starter
- scale-radio-autoswitch
- scale-radio-fun-line
- scale-radio-hardware

Why this matters:
- turns the new journal and README discipline into an actual PR gate
- reduces drift as development starts
- supports agent pickup by making component hygiene visible and enforceable
