### PR TITLE
Add process docs for tech changes, interdependencies, repo-truth cleanup, and review cadence

### DIFF
--- a/contracts/repo/component_interdependency_map_v1.md
+++ b/contracts/repo/component_interdependency_map_v1.md
@@ -1,0 +1,91 @@
+# COMPONENT INTERDEPENDENCY MAP V1
+
+## Purpose
+This document records the current liveable interdependency model between active components.
+
+## Leading rule
+Dependencies should be explicit, minimal, and stable enough that one component can evolve without forcing hidden changes into another.
+
+## Layer view
+### Base runtime layer
+- `scale-radio-starter`
+- provides startup/runtime glue and accepted startup baseline
+- other components should not assume this layer solved unrelated renderer performance questions unless separately documented
+
+### Experience/runtime components
+- `scale-radio-tuner`
+- `scale-radio-fun-line`
+- `scale-radio-autoswitch`
+- `scale-radio-bridge`
+
+### Hardware/input layer
+- `scale-radio-hardware`
+- future production relation to frontpanel-engine remains open
+
+## Liveable dependency rules
+### scale-radio-starter
+Depends on:
+- Volumio / touch_display / kiosk runtime
+Provides to others:
+- base runtime startup and handover environment
+Must not silently absorb feature ownership from tuner, fun-line, or bridge.
+
+### scale-radio-tuner
+Depends on:
+- starter/runtime base
+- overlay owner coordination file
+- hardware/input path later, but not yet as a governed hard dependency
+Provides to others:
+- primary Radio Scale visible experience
+- shared overlay-owner participation
+Must not depend on bridge for core opening/renderer ownership.
+
+### scale-radio-fun-line
+Depends on:
+- starter/runtime base
+- coexistence rules with tuner
+Provides to others:
+- overlay / experience layer only
+Liveable rule:
+- tuner and fun-line may coexist on the same system, but must not run as two heavy active renderers simultaneously.
+
+### scale-radio-bridge
+Depends on:
+- starter/runtime base
+- Volumio/plugin runtime
+Provides to others:
+- provider-layer metadata enrichment, lyrics, Spotify match, playlist add, caching
+Liveable rule:
+- bridge is provider-layer only and must not take renderer/controller ownership.
+
+### scale-radio-autoswitch
+Depends on:
+- HiFiBerry ADC hardware path
+- ALSA/systemd runtime
+Provides to others:
+- tape-active / analog-input switching behavior
+Liveable rule:
+- renderer/UI should consume exported state from autoswitch, but autoswitch should not own renderer behavior.
+- source-restore ownership must be explicitly decided before coupling deeper into source/runtime logic.
+
+### scale-radio-hardware
+Depends on:
+- physical donor-hardware assembly and validation
+Provides to others:
+- validated physical input path for later runtime integration
+Liveable rule:
+- hardware validation may proceed standalone before being treated as a hard tuner dependency.
+- tuner real-world flywheel behavior becomes more meaningful after hardware validation, but tuner governance must not stall entirely on hardware.
+
+## Current critical live dependencies
+- tuner <-> fun-line: shared overlay ownership and deep-idle coexistence
+- starter -> all runtime components: startup/handover base
+- bridge -> tuner/fun-line/other consumers: provider-layer metadata only
+- autoswitch -> future renderer/source consumers: exported tape-active state still needed
+- hardware -> future tuner/input realism: real dependency later, partial dependency now
+
+## Open dependency decisions
+- exact tuner <- hardware runtime contract after AS5600 validation
+- exact autoswitch -> source-restore ownership
+- exact starter -> runtime truth mapping for stable payload/source tree in repo
+- exact bridge interaction with future overlay/open-entry artifacts if those expand

--- a/contracts/repo/repo_truth_cleanup_backlog_v1.md
+++ b/contracts/repo/repo_truth_cleanup_backlog_v1.md
@@ -1,0 +1,58 @@
+# REPO TRUTH CLEANUP BACKLOG V1
+
+## Purpose
+This backlog records where current repository truth is still incomplete or uncertain and needs explicit normalization.
+
+## Highest priority
+### 1. scale-radio-starter
+Current uncertainty:
+- exact component-path/payload/source tree still not cleanly grounded from surviving context
+- exact stable asset inventory for `v0.2.2 stable` remains uncertain
+Required action:
+- verify actual files in repo
+- map accepted stable baseline into explicit repo paths
+- update README/journal with final repo truth
+
+### 2. scale-radio-fun-line
+Current uncertainty:
+- exact repo-normalized payload structure for overlay/source/future packs remains unresolved
+- latest nonleading builds need clearer repo labeling as partial/experimental
+Required action:
+- lock repo truth around `0.4.2`
+- identify where later 0.5.0/0.6.0 material lives and mark it explicitly nonleading
+- normalize overlay/source/packs structure under component governance
+
+### 3. scale-radio-hardware
+Current uncertainty:
+- source-of-truth under `components/scale-radio-hardware/` still incomplete
+- standalone AS5600 tester source and related docs/mechanical assets need normalization
+Required action:
+- commit/normalize source, wiring docs, and validation-lane structure
+- keep component on `dev/hardware` until live validation exists
+
+## Medium priority
+### 4. scale-radio-tuner
+Current uncertainty:
+- exact payload subtree naming in repo versus governed artifact model could be clearer
+- deploy lane maturity still trails bridge
+Required action:
+- align payload naming with artifact model and release numbering rules
+- define the next deploy candidate lane after validation
+
+### 5. scale-radio-bridge
+Current uncertainty:
+- whether `0.2.3_db_cache_r1` becomes the next locked stable baseline
+Required action:
+- keep `rsob_022sf22l.zip` as rollback anchor until field validation completes
+- promote or reject the DB-cache branch explicitly
+
+### 6. scale-radio-autoswitch
+Current uncertainty:
+- future technology shape may change from bash/systemd to plugin-based
+Required action:
+- if that migration begins, use the technology-change process before changing repo truth
+
+## Rule
+No uncertain area should stay hidden. It must be either:
+- normalized into repo truth, or
+- explicitly listed here as unresolved.

--- a/contracts/repo/status_and_decision_review_cadence_v1.md
+++ b/contracts/repo/status_and_decision_review_cadence_v1.md
@@ -1,0 +1,54 @@
+# STATUS AND DECISION REVIEW CADENCE V1
+
+## Purpose
+This cadence keeps current-state journals, stream journals, and decision logs alive enough for active development.
+
+## Leading rule
+Status and decisions are not archival paperwork. They are active operating documents.
+
+## Minimum cadence
+### On every meaningful change
+Update at least:
+- component `stream_v1.md`
+- component `current_state_v1.md` if the operational reality changed
+
+Meaningful change includes:
+- new accepted baseline
+- deploy or rollback validation result
+- component path normalization
+- technology-shape change
+- important risk discovered
+- promotion or demotion of a branch/baseline
+
+### Weekly integration review
+At least once per active week, integration should review:
+- components with unresolved repo-truth uncertainty
+- components whose `current_state_v1.md` still says `payload_partial`
+- components with open technology-shape questions
+- components with stale baselines or missing validation
+
+### Before promotion to main truth
+Before treating a component baseline as current truth, verify:
+- current_state is updated
+- stream is updated
+- README matches the same truth
+- decision log reflects any newly locked decision
+
+## Triggered review cases
+A forced review is required when:
+- a component changes technology shape
+- a component adds/removes artifacts
+- a component changes rollback anchor
+- a component changes deploy entrypoint
+- a component moves from dev-only toward main-truth readiness
+
+## Ownership
+- specialist chat: proposes component reality
+- integration chat: normalizes repo truth and cross-component consistency
+- operator: validates runtime/deploy results on target Pi
+
+## Practical rule for speed
+If time is tight:
+- update stream first
+- update current_state second
+- update decision log only when a choice is actually locked

--- a/contracts/repo/technology_change_process_v1.md
+++ b/contracts/repo/technology_change_process_v1.md
@@ -1,0 +1,75 @@
+# TECHNOLOGY CHANGE PROCESS V1
+
+## Purpose
+This process governs component-level technology changes, such as replacing a bash/service implementation with a Volumio plugin, changing runtime language, changing deployment style, or moving a runtime responsibility between artifacts.
+
+## Trigger
+Use this process whenever a component changes one of these:
+- implementation form
+- runtime entrypoint
+- deploy contract
+- rollback contract
+- ownership boundary
+- branch/release structure
+
+Examples:
+- bash/service component -> Volumio plugin
+- Volumio plugin -> service/helper split
+- single artifact -> multi-artifact component
+- polling runtime -> event-driven runtime
+
+## Mandatory steps
+### 1. State the proposed change clearly
+The proposal must name:
+- current technology shape
+- proposed technology shape
+- why the change is being made
+- what stays the same
+- what breaks if not handled carefully
+
+### 2. Preserve component identity
+A technology change does not automatically create a new component.
+Default rule:
+- keep the same component
+- document the new artifact/runtime model inside that component
+
+Only split into a new component if governance explicitly records a boundary change.
+
+### 3. Protect rollback first
+Before the change is treated as active work, define:
+- rollback anchor
+- rollback procedure
+- what must be removed/unregistered on rollback
+- what old artifact remains the safety baseline
+
+### 4. Update repo truth before claiming migration
+Before calling the migration active, update:
+- component `current_state_v1.md`
+- component `stream_v1.md`
+- component README
+- decision log if the technology change is binding
+
+### 5. Keep naming and release discipline
+During technology change:
+- component name stays normalized
+- artifact roles become explicit
+- release numbering stays component-level unless governance explicitly splits it
+
+### 6. Validate deploy contract again
+A technology change reopens deploy validation.
+At minimum re-check:
+- install path
+- activation behavior
+- rollback behavior
+- unregistration behavior if plugin-based
+- target-Pi runtime behavior
+
+## Decision rule
+A technology change becomes active repo truth only when:
+1. rollback is explicit
+2. journals are updated
+3. runtime/deploy impact is documented
+4. the old authoritative baseline is still recoverable
+
+## Autoswitch note
+If `scale-radio-autoswitch` moves from bash/systemd toward a Volumio plugin, treat that as a technology change under this process. Do not silently replace the current service-based truth.


### PR DESCRIPTION
Adds the next process/governance layer needed before broader development starts.

Included:
- `contracts/repo/technology_change_process_v1.md`
- `contracts/repo/component_interdependency_map_v1.md`
- `contracts/repo/repo_truth_cleanup_backlog_v1.md`
- `contracts/repo/status_and_decision_review_cadence_v1.md`

What this does:
- defines the mandatory process for component technology changes
- creates a liveable component interdependency map
- records where repo truth is still incomplete or uncertain and prioritizes cleanup
- defines a minimal status/decision review cadence that can survive active development

Why this matters now:
- autoswitch may change technology shape
- several components still have repo-truth uncertainty
- dev is about to start and interdependencies need one shared source
- journals/decisions must stay active without becoming heavy bureaucracy
