### PR TITLE
Add SI recovery onboarding and governance continuity docs

### DIFF
--- a/contracts/repo/chatgpt_github_connection_model_v1.md
+++ b/contracts/repo/chatgpt_github_connection_model_v1.md
@@ -1,0 +1,40 @@
+# CHATGPT GITHUB CONNECTION MODEL V1
+
+## Purpose
+This file records the practical GitHub access model used by this chat for repository work on `SH99999/mediastreamer`.
+
+## Current connection path
+This chat reaches the repository through the ChatGPT GitHub connector.
+
+The connection has been used successfully for repository tasks such as:
+- reading repository files
+- reading recent pull requests
+- checking active branches
+- creating a dedicated working branch
+- creating new files on that branch
+
+## Practical operating model
+The practical working pattern is:
+1. inspect current repo truth from GitHub
+2. prepare changes in a dedicated branch
+3. write repo-native files or updates
+4. open a pull request to `main`
+5. let the repository owner review and merge
+
+## Limits that matter operationally
+This is not a local shell-based `git` workflow.
+
+The chat should not assume:
+- local `git` CLI usage
+- SSH-based push from the chat
+- direct Pi-side file editing through GitHub access alone
+- direct runtime testing just because repo write access exists
+
+## What this means for repository governance
+- important operational knowledge must be written into the repo
+- governance and journal files are required for continuity
+- working rules should not remain only in chat history
+- reviewable PR-based changes are the preferred way to mutate repo truth
+
+## Recovery rule
+If another chat takes over, it should verify the connector still works for the repository, then continue from the repo-native governance and journal documents rather than from memory.

--- a/contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md
+++ b/contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md
@@ -1,0 +1,69 @@
+# SYSTEM INTEGRATION CHAT SETUP AND WORKING AGREEMENTS V1
+
+## Purpose
+This file documents the current setup, role, and working agreements of the system integration / normalization lane so that another chat can continue without rebuilding the operating model from memory.
+
+## Current role of this lane
+System integration / normalization is responsible for:
+- git management and repo-control-plane changes
+- branch doctrine and branch hygiene
+- workflow model and deploy/rollback semantics
+- repository governance and document normalization
+- cross-component consistency and handoff quality
+
+This lane is not the owner of detailed specialist feature implementation inside Bridge, Tuner, Starter, AutoSwitch, Fun Line, or Hardware.
+
+## Current repository footing
+- repository: `SH99999/mediastreamer`
+- canonical truth branch: `main`
+- active component branches currently recognized:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- open governance/process work known at the time of writing:
+  - PR `#40` from branch `process-v1` is open and contains process docs for technology change handling, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence
+
+## Current operational baseline
+- `main` is the operator-visible control plane for workflows, governance, contracts, and accepted stable repo truth
+- active component work belongs on `dev/<component>` unless governance explicitly promotes that component block to `main`
+- deployment uses clean-replace semantics, not update-in-place
+- deploy and rollback workflows live on `main` and operate against a selected `git_ref`
+- the repo-shipped wrapper model is the accepted workflow entrypoint model
+- rollback for plugin-based components must also handle Volumio plugin unregistration when relevant
+
+## Established git process
+1. identify whether the change is component-local or repo-control-plane
+2. make repo-control-plane and governance changes in a dedicated working branch
+3. keep change scope reviewable and explicit
+4. open a PR to `main`
+5. operator review/approval/merge remains the acceptance gate
+6. after merge, keep active `dev/<component>` branches aligned to current `main` whenever practical
+7. whenever repo truth changes materially, update the matching governance and journal files
+
+## Documentation agreements established here
+- governance doctrine belongs in `contracts/repo/`
+- system integration journals belong in `journals/system-integration-normalization/`
+- agent-recovery and onboarding material belongs in `docs/agents/`
+- repo-facing documentation is in English
+- chat memory alone is not sufficient for operational truth
+- if a working rule matters later, it should be written into the repo
+
+## Journal agreements established here
+- SI/N must maintain repo-native status, decisions, and stream files
+- active components must keep `current_state_v1.md` and `stream_v1.md`
+- stream files should stay factual and append-only
+- current-state files should reflect tested reality, not intention
+
+## Replacement-chat rule
+A replacement chat should not start by inventing new structure, renaming governance paths, or replaying old debates from memory.
+
+It should first read the governance index, onboarding file, and SI journals, then inspect current open PRs and active branches, and only then propose further repo changes.
+
+## Immediate unresolved areas
+- PR `#40` is still pending review and merge
+- non-bridge deploy maturity is still uneven
+- some repo-truth cleanup and superseded-document cleanup still remain
+- governance and journal discipline should continue to be tightened without creating parallel doctrine tracks

--- a/contracts/repo/system_integration_governance_index_v1.md
+++ b/contracts/repo/system_integration_governance_index_v1.md
@@ -1,0 +1,49 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V1
+
+## Purpose
+This file is the stable entrypoint for system integration / normalization governance, recovery, and journal truth.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding, skills, and recovery material
+
+## Read order for a replacement chat
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+8. `contracts/repo/chatgpt_github_connection_model_v1.md`
+9. `docs/agents/system_integration_recovery_onboarding_v1.md`
+10. `journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md`
+11. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md`
+12. `journals/system-integration-normalization/stream_v1.md`
+
+## Active component journal map
+- `journals/scale-radio-bridge/current_state_v1.md`
+- `journals/scale-radio-bridge/stream_v1.md`
+- `journals/scale-radio-tuner/current_state_v1.md`
+- `journals/scale-radio-tuner/stream_v1.md`
+- `journals/scale-radio-starter/current_state_v1.md`
+- `journals/scale-radio-starter/stream_v1.md`
+- `journals/scale-radio-autoswitch/current_state_v1.md`
+- `journals/scale-radio-autoswitch/stream_v1.md`
+- `journals/scale-radio-fun-line/current_state_v1.md`
+- `journals/scale-radio-fun-line/stream_v1.md`
+- `journals/scale-radio-hardware/current_state_v1.md`
+- `journals/scale-radio-hardware/stream_v1.md`
+
+## System integration journal map
+- `journals/system-integration-normalization/STATUS_system_integration_normalization_v1.md`
+- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v1.md`
+- `journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md`
+- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md`
+- `journals/system-integration-normalization/stream_v1.md`
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- a new chat should start from these files before proposing repo-control-plane changes

--- a/docs/agents/system_integration_recovery_onboarding_v1.md
+++ b/docs/agents/system_integration_recovery_onboarding_v1.md
@@ -1,0 +1,73 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V1
+
+## Purpose
+This file is the fast re-entry guide for a replacement chat if the current system integration / normalization conversation is lost.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch/process consistency
+- workflow and rollback doctrine
+- journal discipline
+- cross-component normalization
+
+Do not assume ownership of deep specialist implementation inside component payloads unless the repo state clearly requires it.
+
+## Current repo truth snapshot
+- repository: `SH99999/mediastreamer`
+- default truth branch: `main`
+- active component branches:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- current known open governance/process PR at handoff time:
+  - PR `#40` from `process-v1`
+- current workflow doctrine:
+  - workflows live on `main`
+  - deploy/rollback operate against a selected `git_ref`
+  - clean-replace semantics are required
+- currently best-validated deploy lane:
+  - Bridge from `dev/bridge`
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v1.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_journal_policy_v2.md`
+5. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+6. `contracts/repo/chatgpt_github_connection_model_v1.md`
+7. `journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md`
+8. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md`
+9. `journals/system-integration-normalization/stream_v1.md`
+10. relevant component `current_state_v1.md` and `stream_v1.md` files
+
+## First actions for a replacement chat
+1. verify current open PRs and their merge state
+2. verify current active branches and whether any `dev/<component>` branch has drifted behind `main`
+3. read SI status, decisions, and stream before proposing new governance
+4. read the relevant component journals before touching deployment or rollback doctrine
+5. update the repo rather than relying on reconstructed chat memory
+
+## What not to do
+- do not invent a parallel governance directory
+- do not create a second truth branch
+- do not split a component into multiple branches only because it has multiple artifacts or plugins
+- do not treat chat memory as stronger than repo-native governance and journal truth
+- do not loosen clean-replace or rollback doctrine without explicit repo updates
+
+## Immediate open themes at handoff time
+- PR `#40` still needs operator review/approval/merge
+- process discipline for technology changes and interdependency handling is being formalized further
+- non-bridge deploy maturity is still not as proven as Bridge
+- governance cleanup should stay additive and coherent, not fragment into competing documents
+
+## Minimum completion condition for a new SI task
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what branch doctrine is active
+- where the component journals live
+- what the current deploy/rollback doctrine is
+- which PRs are still open
+- which docs are canonical versus merely historical

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md
@@ -1,0 +1,99 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v2 file supersedes the earlier v1 snapshot as the current repo-facing SI/N decision log.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-01
+- Status: locked
+- Decision: `main` is the canonical truth branch for workflows, governance, contracts, and accepted stable artifacts.
+- Date context: repository normalization phase
+- Why this was chosen: one operator-visible control plane is required to avoid branch and workflow ambiguity.
+- What it affects: workflow placement, governance docs, accepted stable payload promotion.
+- What it explicitly does NOT affect: whether unstable component work may continue on `dev/*` branches.
+- Follow-up needed: keep branch doctrine wording consistent across docs.
+
+### DEC-system_integration_normalization-02
+- Status: locked
+- Decision: active component work belongs on `dev/<component>` unless the component block is already stable enough for `main` truth or governance explicitly promotes it.
+- Date context: branch cleanup and normalization phase
+- Why this was chosen: separates unstable work from stable operator-facing repo truth.
+- What it affects: branch selection for active component lanes.
+- What it explicitly does NOT affect: intentional promotion of a stable component block to `main`.
+- Follow-up needed: keep active `dev/*` branches aligned to current `main` whenever practical.
+
+### DEC-system_integration_normalization-03
+- Status: locked
+- Decision: deployment uses clean-replace semantics, not update-in-place semantics.
+- Date context: early Bridge deployment governance
+- Why this was chosen: current plugin/runtime stability is not high enough for safe in-place updates.
+- What it affects: deploy candidate scripts, rollback logic, payload install behavior.
+- What it explicitly does NOT affect: future possibility of update-in-place once stability is proven.
+- Follow-up needed: encode this in all new component deploy candidate scripts.
+
+### DEC-system_integration_normalization-04
+- Status: locked
+- Decision: workflows must live on `main` and accept a selected `git_ref`.
+- Date context: manual workflow visibility normalization
+- Why this was chosen: GitHub manual workflows are operator-friendly when visible on the default truth branch.
+- What it affects: manual deploy and rollback workflows.
+- What it explicitly does NOT affect: where evolving component payloads live.
+- Follow-up needed: keep only the current supported workflow generation visible.
+
+### DEC-system_integration_normalization-05
+- Status: locked
+- Decision: the repo-shipped wrapper is the accepted deployment entrypoint model.
+- Date context: stale Pi-local wrapper mismatch investigation
+- Why this was chosen: multi-host consistency requires the repo to ship the execution model.
+- What it affects: wrapper logic and workflow execution path.
+- What it explicitly does NOT affect: existence of older Pi-local wrappers; those simply should not be trusted.
+- Follow-up needed: extend wrapper-backed maturity beyond Bridge.
+
+### DEC-system_integration_normalization-06
+- Status: locked
+- Decision: rollback must also unregister the plugin in Volumio when relevant.
+- Date context: Bridge rollback hardening
+- Why this was chosen: removing files without unregistering plugin state leaves operational residue.
+- What it affects: Bridge rollback logic and future plugin rollback paths.
+- What it explicitly does NOT affect: non-plugin components that have no Volumio plugin registration.
+- Follow-up needed: apply the same rule to future plugin-based components.
+
+### DEC-system_integration_normalization-07
+- Status: locked
+- Decision: Bridge may remain inactive after install for now if runtime deployment, overlay reachability, and rollback are working.
+- Date context: validated Bridge deploy tests
+- Why this was chosen: runtime path and overlay behavior proved operational even though activation state is not yet ideal.
+- What it affects: current Bridge acceptance threshold.
+- What it explicitly does NOT affect: future expectation of better activation behavior.
+- Follow-up needed: keep documenting this as an accepted temporary state until improved.
+
+### DEC-system_integration_normalization-08
+- Status: locked
+- Decision: governance doctrine belongs in `contracts/repo/`; agent-facing onboarding and recovery material belongs in `docs/agents/` and must point back to governance and journals.
+- Date context: governance recovery and handoff hardening
+- Why this was chosen: one governance home is required, but replacement chats also need an explicit recovery entrypoint.
+- What it affects: placement of repo-control-plane doctrine and onboarding material.
+- What it explicitly does NOT affect: component-specific journals under `journals/<component>/`.
+- Follow-up needed: avoid creating parallel governance directories.
+
+### DEC-system_integration_normalization-09
+- Status: locked
+- Decision: system integration must maintain repo-native status, decisions, and stream files.
+- Date context: governance recovery and handoff hardening
+- Why this was chosen: SI/N owns the repo-control-plane and cannot depend on chat-only memory.
+- What it affects: required documentation discipline for SI/N itself.
+- What it explicitly does NOT affect: the existing requirement for active components to maintain their own journals.
+- Follow-up needed: keep SI stream updated after each meaningful repo-control-plane change.
+
+### DEC-system_integration_normalization-10
+- Status: locked
+- Decision: repo-control-plane changes should be prepared in dedicated branches and reviewed through pull requests to `main`.
+- Date context: current git operating discipline
+- Why this was chosen: reviewable PRs keep governance and integration changes explicit and auditable.
+- What it affects: governance changes, workflow changes, journal additions, and repo-control-plane modifications.
+- What it explicitly does NOT affect: the owner's right to decide approval timing or merge order.
+- Follow-up needed: keep SI/governance changes scoped and reviewable.
+
+## Superseded Decisions
+- No individual locked decision is superseded in this v2 file.
+- The earlier v1 decision-log file remains a historical snapshot, while this v2 file becomes the current operating decision log.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md
@@ -1,0 +1,138 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v2 file supersedes the earlier v1 snapshot as the current repo-facing SI/N status file.
+
+## 1. Scope
+- component name: system_integration_normalization
+- legacy names / aliases: SI/N, integration chat, normalization lane
+- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, cross-component integration policy, repo-native handoff quality
+- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware feature implementation, source engine implementation
+
+## 2. Current Functional Status
+- what currently works:
+  - `main` holds the active governance, workflow, contract, and agent-onboarding control plane
+  - repo-driven deployment works through the current generic deploy/rollback workflow family on `main`
+  - bridge deploy lane is operational from `dev/bridge`
+  - bridge rollback unregisters the plugin and restarts Volumio
+  - active component journals now exist in repo form for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+  - active component README hygiene and journal presence are now CI-checked on `main`
+  - system integration now has a repo-native governance index, onboarding note, status, decisions, and stream path
+- what partially works:
+  - the process-doc extension in PR `#40` is open but not yet merged
+  - non-bridge deploy maturity is still uneven compared with Bridge
+  - some repo-truth cleanup is still active and not all older lower-value documents have been retired yet
+- what is broken:
+  - there is still no equally mature deploy/rollback proof across all active components
+  - governance cleanup is not finished enough to guarantee zero ambiguity in every older document
+- what was tested:
+  - bridge deploy and rollback through the repo-driven workflow model on a real Pi
+  - wrapper-free repo-driven execution path
+  - active-component journal/README CI on `main`
+- what is untested:
+  - full generic deploy/rollback validation for every active component branch
+  - stronger CI enforcement for SI-specific recovery/onboarding discipline
+
+## 3. Repository Mapping
+- correct component path in repo: `journals/system-integration-normalization/`
+- correct payload path(s): none
+- correct branch: `main` for truth; dedicated temporary working branches for repo-control-plane changes
+- whether component belongs on main or dev branch right now: main
+
+## 4. Locked Decisions
+### DEC-SIN-01
+- decision: `main` is the truth branch for workflows, governance, contracts, and accepted stable artifacts.
+- rationale: operator-visible execution and repo doctrine need one canonical source.
+- impact: workflows and governance live on `main`.
+
+### DEC-SIN-02
+- decision: active component work belongs on `dev/<component>` unless the component block is intentionally promoted to `main` truth.
+- rationale: separates unstable component work from the stable control plane.
+- impact: active component development remains on `dev/*` lanes unless governance says otherwise.
+
+### DEC-SIN-03
+- decision: deployment uses clean-replace semantics, not update-in-place.
+- rationale: current runtime maturity is still not strong enough for safe in-place mutation.
+- impact: deploy candidate scripts and workflow behavior remove/replace instead of patching live state.
+
+### DEC-SIN-04
+- decision: workflows must live on `main` and accept a selected `git_ref`.
+- rationale: manual operator-visible entrypoints must remain on the truth branch.
+- impact: deploy and rollback workflow families stay on `main`.
+
+### DEC-SIN-05
+- decision: the repo-shipped wrapper model is the accepted deployment entrypoint model.
+- rationale: stale Pi-local wrappers create drift and multi-host inconsistency.
+- impact: wrapper behavior is controlled from repo truth.
+
+### DEC-SIN-06
+- decision: rollback must unregister the plugin in Volumio when relevant.
+- rationale: file removal alone leaves operational residue.
+- impact: plugin rollback paths must clean runtime state and registration state.
+
+### DEC-SIN-07
+- decision: Bridge may remain inactive after install for now if runtime deployment, overlay reachability, and rollback are working.
+- rationale: current acceptance is based on proven runtime path and rollback reality.
+- impact: Bridge acceptance threshold remains pragmatic until activation behavior improves.
+
+### DEC-SIN-08
+- decision: governance doctrine belongs in `contracts/repo/`, while agent-facing onboarding and recovery material belongs in `docs/agents/` and must point back to governance and journals.
+- rationale: one governance home is needed, but agent recovery docs still need an explicit place.
+- impact: reduces future scattering of process truth across random repo paths.
+
+### DEC-SIN-09
+- decision: system integration must maintain repo-native status, decisions, and stream files.
+- rationale: SI/N governs the repo-control-plane and cannot depend on chat-only memory.
+- impact: SI/N now follows the same journal discipline expected from active components.
+
+## 5. Open Decisions
+- whether PR `#40` should merge as-is or receive follow-up refinement before merge
+- how strict the next SI-specific CI enforcement should become
+- whether older lower-value governance files should be removed or simply remain indexed as lower-precedence historical material
+- how quickly non-bridge deploy lanes should be normalized to the same maturity standard as Bridge
+
+## 6. Runtime / Deployment Notes
+- install assumptions:
+  - self-hosted Pi runner with labels matching workflow requirements
+  - repo checkout available during workflow run
+- uninstall / rollback assumptions:
+  - active runtime path can be moved aside
+  - Volumio restart and recovery check are required
+- services:
+  - `volumio`
+  - `volumio-kiosk`
+- configs:
+  - component-specific paths under `/data/configuration/...`
+  - Volumio plugin registration state in `/data/configuration/plugins.json`
+- ports:
+  - Bridge overlay has been validated on `:5511`
+- files / folders that matter:
+  - `.github/workflows/component-test-deploy-v6.yml`
+  - `.github/workflows/component-test-rollback-v6.yml`
+  - `tools/deploy/sr-deploy-wrapper.sh`
+  - `contracts/repo/`
+  - `journals/system-integration-normalization/`
+- dependencies:
+  - repo checkout on workflow runner
+  - active component branch/payload
+
+## 7. Known Risks
+- technical risks:
+  - non-bridge deploy lanes are still not equally proven
+  - some older governance material may still create noise until cleanup continues
+- integration risks:
+  - active `dev/<component>` branches drifting behind `main`
+  - repo truth being changed without matching journal/governance updates
+- rollback risks:
+  - only Bridge rollback is currently well-proven
+- handoff risks:
+  - recovery quality falls quickly if SI stream and onboarding docs stop being maintained
+
+## 8. Next Recommended Steps
+1. merge or finalize the process-doc layer currently represented by PR `#40`
+2. keep the SI stream updated for every meaningful repo-control-plane change
+3. decide whether SI recovery/onboarding files should gain explicit CI enforcement
+4. continue normalizing deploy maturity beyond Bridge
+5. keep active component branches aligned to current `main` whenever practical
+
+## 9. Hand-off Notes
+A new specialist or integration chat should start from the governance index, onboarding file, SI status, SI decisions, SI stream, and only then move into component-specific journals and open PR review.

--- a/journals/system-integration-normalization/stream_v1.md
+++ b/journals/system-integration-normalization/stream_v1.md
@@ -1,0 +1,56 @@
+# STREAM — system_integration_normalization
+
+## Entries
+
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 / main / PR #31 merged
+- branch doctrine, component artifact model, and naming/release numbering standards were added
+- purpose: stop recurring branch and multi-artifact ambiguity
+
+### 2026-04-13 / main / PR #32 merged
+- repo-level agent onboarding files and skills were added
+- purpose: reduce repeated context rebuilding for future agent work
+
+### 2026-04-13 / main / PR #33 merged
+- canonical governance source precedence and overlay contract docs were added
+- purpose: reduce doctrine conflicts and give overlay behavior a formal governance home
+
+### 2026-04-13 / main / PR #35 merged
+- governance CI wording was corrected after a brittle text-match failure
+- purpose: keep governance checks usable against real repo wording
+
+### 2026-04-13 / main / PR #36 merged
+- initial component current-state and stream journals were added for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+- purpose: move active component handoff memory into repo-native journals
+
+### 2026-04-13 / main / PR #37 merged
+- missing tuner current-state journal gap was closed
+- purpose: restore journal completeness for active components
+
+### 2026-04-13 / main / PR #38 merged
+- stub component READMEs were replaced with short governed component overviews
+- purpose: improve human and agent pickup quality at component roots
+
+### 2026-04-13 / main / PR #39 merged
+- CI checks for active component journals and READMEs were added
+- purpose: turn journal discipline into repo-enforced hygiene
+
+### 2026-04-14 / process-v1 / PR #40 opened
+- process docs for technology changes, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence were proposed
+- state: open and pending operator review
+
+### 2026-04-14 / sin-recovery-v1 / current branch
+- governance recovery pack was added
+- included:
+  - SI governance index
+  - SI chat setup and working agreements doc
+  - ChatGPT GitHub connection model doc
+  - replacement-chat onboarding doc
+  - SI status v2
+  - SI decisions v2
+  - SI stream v1
+- purpose: reduce chat-loss risk and keep SI/N operating memory inside Git


### PR DESCRIPTION
Adds a repo-native recovery/onboarding pack for the system integration / normalization lane.

Included:
- `contracts/repo/system_integration_governance_index_v1.md`
- `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
- `contracts/repo/chatgpt_github_connection_model_v1.md`
- `docs/agents/system_integration_recovery_onboarding_v1.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v2.md`
- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v2.md`
- `journals/system-integration-normalization/stream_v1.md`

What this does:
- creates a stable entrypoint for another chat if the current SI/N conversation is lost
- documents this lane's current setup, working agreements, and established git process
- records the practical GitHub connector access model used by this chat
- upgrades SI/N repo memory from status + decisions only to status + decisions + stream
- adds v2 SI status and decision docs reflecting the current governance/journal state

Why this matters now:
- governance and journal doctrine has grown quickly and should no longer depend on chat memory
- SI/N now needs the same repo-native continuity discipline required from active components
- operator approval can happen later, but the continuity pack should already be reviewable in Git
