### PR TITLE
Add new-component intake governance and SI v3 doctrine

### DIFF
--- a/contracts/repo/new_component_intake_standard_v1.md
+++ b/contracts/repo/new_component_intake_standard_v1.md
@@ -1,0 +1,64 @@
+# NEW COMPONENT INTAKE STANDARD V1
+
+## Purpose
+This document defines the standard way to introduce a new component into the repository.
+
+## Core rule
+- `main` stays the protected truth branch
+- a new component should normally enter through one bootstrap PR to `main`
+- ongoing work then continues on `dev/<component>`
+
+## Naming
+Use the format:
+- `scale-radio-<component>`
+
+## Minimum bootstrap files
+Add at least:
+- `components/<component>/README.md`
+- `journals/<component>/current_state_v1.md`
+- `journals/<component>/stream_v1.md`
+
+## Branch pattern
+Use:
+- `dev/<component-suffix>`
+
+## Minimum README content
+- purpose
+- boundaries
+- non-goals
+- journal links
+
+## Minimum current-state content
+- what exists now
+- what works
+- what is untested
+- next step
+
+## Minimum stream content
+- bootstrap created
+- payload imported
+- deploy tested
+- rollback tested
+- branch realigned to `main`
+
+## Process
+1. define the canonical component name
+2. define the boundary
+3. prepare the bootstrap files in a dedicated branch
+4. open one bundled PR to `main`
+5. after merge, use `dev/<component>` as the long-lived work lane
+
+## Communication rule
+Use concise repo-facing communication.
+Provide exact filenames, paths, and branch names.
+Bundle related setup changes together.
+
+## Decision rule
+Escalate only when naming, boundaries, branch placement, or governance would change.
+
+## Success condition
+The component is ready when:
+- one bootstrap PR was enough
+- `main` stayed protected
+- the component has a clear root and journals
+- future work can continue from `dev/<component>`

--- a/contracts/repo/new_component_intake_standard_v2.md
+++ b/contracts/repo/new_component_intake_standard_v2.md
@@ -1,0 +1,88 @@
+# NEW COMPONENT INTAKE STANDARD V2
+
+Status: supersedes `contracts/repo/new_component_intake_standard_v1.md` as the canonical new-component intake standard.
+
+## Purpose
+This document defines the standard way to introduce a new component into the repository.
+
+## Core rule
+- `main` stays the protected truth branch
+- a new component should normally enter through one bootstrap PR to `main`
+- ongoing component work then continues on `dev/<component-suffix>`
+
+## Tokens used in this standard
+### Canonical component name
+Use the full governed component name:
+- `scale-radio-<component-suffix>`
+
+Example:
+- `scale-radio-bridge`
+
+### Component suffix
+Use the short suffix token taken from the canonical component name:
+- `bridge`
+- `tuner`
+- `starter`
+
+## Naming and path rule
+For a new component:
+- component root path uses the canonical component name
+- journal path uses the canonical component name
+- branch path uses the component suffix
+
+Example:
+- canonical component name: `scale-radio-bridge`
+- component root: `components/scale-radio-bridge/`
+- journals: `journals/scale-radio-bridge/`
+- work branch: `dev/bridge`
+
+## Minimum bootstrap files
+Add at least:
+- `components/scale-radio-<component-suffix>/README.md`
+- `journals/scale-radio-<component-suffix>/current_state_v1.md`
+- `journals/scale-radio-<component-suffix>/stream_v1.md`
+
+## Minimum README content
+- purpose
+- boundaries
+- non-goals
+- journal links
+
+## Minimum current-state content
+- what exists now
+- what works
+- what is untested
+- next step
+
+## Minimum stream content
+- bootstrap created
+- payload imported
+- deploy tested
+- rollback tested
+- branch realigned to `main`
+
+## Branch pattern
+Use:
+- `dev/<component-suffix>`
+
+## Process
+1. define the canonical component name as `scale-radio-<component-suffix>`
+2. define the boundary
+3. prepare the bootstrap files in a dedicated branch
+4. open one bundled PR to `main`
+5. after merge, use `dev/<component-suffix>` as the long-lived work lane
+
+## Communication rule
+Use concise repo-facing communication.
+Provide exact filenames, paths, and branch names.
+Bundle related setup changes together.
+
+## Decision rule
+Escalate only when naming, boundaries, branch placement, or governance would change.
+
+## Success condition
+The component is ready when:
+- one bootstrap PR was enough
+- `main` stayed protected
+- the component has a clear root and journals in canonical paths
+- future work can continue from `dev/<component-suffix>`

--- a/contracts/repo/system_integration_governance_index_v2.md
+++ b/contracts/repo/system_integration_governance_index_v2.md
@@ -1,0 +1,29 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V2
+
+## Purpose
+This file is the current entrypoint for system integration governance, recovery, journal truth, and new-component intake.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding and recovery material
+
+## Read order
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/new_component_intake_standard_v1.md`
+8. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+9. `contracts/repo/chatgpt_github_connection_model_v1.md`
+10. `docs/agents/system_integration_recovery_onboarding_v2.md`
+11. `journals/system-integration-normalization/STATUS_system_integration_normalization_v3.md`
+12. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v3.md`
+13. `journals/system-integration-normalization/stream_v1.md`
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- new components should use the standard intake path instead of ad-hoc structure

--- a/contracts/repo/system_integration_governance_index_v3.md
+++ b/contracts/repo/system_integration_governance_index_v3.md
@@ -1,0 +1,29 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V3
+
+## Purpose
+This file is the current entrypoint for system integration governance, recovery, journal truth, and new-component intake.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding and recovery material
+
+## Read order
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/new_component_intake_standard_v2.md`
+8. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+9. `contracts/repo/chatgpt_github_connection_model_v1.md`
+10. `docs/agents/system_integration_recovery_onboarding_v3.md`
+11. `journals/system-integration-normalization/STATUS_system_integration_normalization_v4.md`
+12. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v4.md`
+13. `journals/system-integration-normalization/stream_v1.md`
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- new components should use the corrected intake standard instead of ad-hoc structure

--- a/docs/agents/system_integration_recovery_onboarding_v2.md
+++ b/docs/agents/system_integration_recovery_onboarding_v2.md
@@ -1,0 +1,54 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V2
+
+## Purpose
+This file is the fast re-entry guide for a replacement chat if the current system integration / normalization conversation is lost.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- journal discipline
+- cross-component normalization
+- new-component intake discipline
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v2.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_journal_policy_v2.md`
+5. `contracts/repo/new_component_intake_standard_v1.md`
+6. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+7. `contracts/repo/chatgpt_github_connection_model_v1.md`
+8. `journals/system-integration-normalization/STATUS_system_integration_normalization_v3.md`
+9. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v3.md`
+10. `journals/system-integration-normalization/stream_v1.md`
+
+## For a new component request
+Use the standard bootstrap path:
+1. define the canonical component name
+2. define the boundary
+3. add the minimum bootstrap files
+4. open one bundled PR to `main`
+5. continue work on `dev/<component>` after merge
+
+## Communication rule
+Be concise.
+Separate facts from decisions.
+Use exact filenames, paths, and branch names.
+Do not ask repeated setup questions when the standard already answers them.
+
+## What not to do
+- do not invent a parallel governance directory
+- do not create a second truth branch
+- do not split a component into multiple branches only because it has multiple artifacts or plugins
+- do not rely on chat memory instead of repo-native governance and journals
+- do not bypass the component bootstrap standard for active new work
+
+## Minimum completion condition for a new SI task
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what branch doctrine is active
+- where journals live
+- what the current deploy and rollback doctrine is
+- what the new-component bootstrap standard is
+- which open PRs still matter

--- a/docs/agents/system_integration_recovery_onboarding_v3.md
+++ b/docs/agents/system_integration_recovery_onboarding_v3.md
@@ -1,0 +1,54 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V3
+
+## Purpose
+This file is the fast re-entry guide for a replacement chat if the current system integration / normalization conversation is lost.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- journal discipline
+- cross-component normalization
+- new-component intake discipline
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v3.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_journal_policy_v2.md`
+5. `contracts/repo/new_component_intake_standard_v2.md`
+6. `contracts/repo/system_integration_chat_setup_and_working_agreements_v1.md`
+7. `contracts/repo/chatgpt_github_connection_model_v1.md`
+8. `journals/system-integration-normalization/STATUS_system_integration_normalization_v4.md`
+9. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v4.md`
+10. `journals/system-integration-normalization/stream_v1.md`
+
+## For a new component request
+Use the standard bootstrap path:
+1. define the canonical component name as `scale-radio-<component-suffix>`
+2. place files under `components/scale-radio-<component-suffix>/`
+3. place journals under `journals/scale-radio-<component-suffix>/`
+4. open one bundled PR to `main`
+5. continue work on `dev/<component-suffix>` after merge
+
+## Communication rule
+Be concise.
+Separate facts from decisions.
+Use exact filenames, paths, and branch names.
+Do not ask repeated setup questions when the standard already answers them.
+
+## What not to do
+- do not invent a parallel governance directory
+- do not create a second truth branch
+- do not split a component into multiple branches only because it has multiple artifacts or plugins
+- do not rely on chat memory instead of repo-native governance and journals
+- do not bypass the corrected component bootstrap standard for active new work
+
+## Minimum completion condition for a new SI task
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what branch doctrine is active
+- where journals live
+- what the current deploy and rollback doctrine is
+- what the corrected new-component bootstrap standard is
+- which open PRs still matter

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v3.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v3.md
@@ -1,0 +1,117 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v3 file supersedes the earlier v2 snapshot as the current repo-facing SI/N decision log.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-01
+- Status: locked
+- Decision: `main` is the canonical truth branch for workflows, governance, contracts, and accepted stable artifacts.
+- Date context: repository normalization phase
+- Why this was chosen: one operator-visible control plane is required to avoid branch and workflow ambiguity.
+- What it affects: workflow placement, governance docs, accepted stable payload promotion.
+- What it explicitly does NOT affect: whether unstable component work may continue on `dev/*` branches.
+- Follow-up needed: keep branch doctrine wording consistent across docs.
+
+### DEC-system_integration_normalization-02
+- Status: locked
+- Decision: active component work belongs on `dev/<component>` unless the component block is already stable enough for `main` truth or governance explicitly promotes it.
+- Date context: branch cleanup and normalization phase
+- Why this was chosen: separates unstable work from stable operator-facing repo truth.
+- What it affects: branch selection for active component lanes.
+- What it explicitly does NOT affect: intentional promotion of a stable component block to `main`.
+- Follow-up needed: keep active `dev/*` branches aligned to current `main` whenever practical.
+
+### DEC-system_integration_normalization-03
+- Status: locked
+- Decision: deployment uses clean-replace semantics, not update-in-place semantics.
+- Date context: early Bridge deployment governance
+- Why this was chosen: current plugin/runtime stability is not high enough for safe in-place updates.
+- What it affects: deploy candidate scripts, rollback logic, payload install behavior.
+- What it explicitly does NOT affect: future possibility of update-in-place once stability is proven.
+- Follow-up needed: encode this in all new component deploy candidate scripts.
+
+### DEC-system_integration_normalization-04
+- Status: locked
+- Decision: workflows must live on `main` and accept a selected `git_ref`.
+- Date context: manual workflow visibility normalization
+- Why this was chosen: GitHub manual workflows are operator-friendly when visible on the default truth branch.
+- What it affects: manual deploy and rollback workflows.
+- What it explicitly does NOT affect: where evolving component payloads live.
+- Follow-up needed: keep only the current supported workflow generation visible.
+
+### DEC-system_integration_normalization-05
+- Status: locked
+- Decision: the repo-shipped wrapper is the accepted deployment entrypoint model.
+- Date context: stale Pi-local wrapper mismatch investigation
+- Why this was chosen: multi-host consistency requires the repo to ship the execution model.
+- What it affects: wrapper logic and workflow execution path.
+- What it explicitly does NOT affect: existence of older Pi-local wrappers; those simply should not be trusted.
+- Follow-up needed: extend wrapper-backed maturity beyond Bridge.
+
+### DEC-system_integration_normalization-06
+- Status: locked
+- Decision: rollback must also unregister the plugin in Volumio when relevant.
+- Date context: Bridge rollback hardening
+- Why this was chosen: removing files without unregistering plugin state leaves operational residue.
+- What it affects: Bridge rollback logic and future plugin rollback paths.
+- What it explicitly does NOT affect: non-plugin components that have no Volumio plugin registration.
+- Follow-up needed: apply the same rule to future plugin-based components.
+
+### DEC-system_integration_normalization-07
+- Status: locked
+- Decision: Bridge may remain inactive after install for now if runtime deployment, overlay reachability, and rollback are working.
+- Date context: validated Bridge deploy tests
+- Why this was chosen: runtime path and overlay behavior proved operational even though activation state is not yet ideal.
+- What it affects: current Bridge acceptance threshold.
+- What it explicitly does NOT affect: future expectation of better activation behavior.
+- Follow-up needed: keep documenting this as an accepted temporary state until improved.
+
+### DEC-system_integration_normalization-08
+- Status: locked
+- Decision: governance doctrine belongs in `contracts/repo/`; agent-facing onboarding and recovery material belongs in `docs/agents/` and must point back to governance and journals.
+- Date context: governance recovery and handoff hardening
+- Why this was chosen: one governance home is required, but replacement chats also need an explicit recovery entrypoint.
+- What it affects: placement of repo-control-plane doctrine and onboarding material.
+- What it explicitly does NOT affect: component-specific journals under `journals/<component>/`.
+- Follow-up needed: avoid creating parallel governance directories.
+
+### DEC-system_integration_normalization-09
+- Status: locked
+- Decision: system integration must maintain repo-native status, decisions, and stream files.
+- Date context: governance recovery and handoff hardening
+- Why this was chosen: SI/N owns the repo-control-plane and cannot depend on chat-only memory.
+- What it affects: required documentation discipline for SI/N itself.
+- What it explicitly does NOT affect: the existing requirement for active components to maintain their own journals.
+- Follow-up needed: keep SI stream updated after each meaningful repo-control-plane change.
+
+### DEC-system_integration_normalization-10
+- Status: locked
+- Decision: repo-control-plane changes should be prepared in dedicated branches and reviewed through pull requests to `main`.
+- Date context: current git operating discipline
+- Why this was chosen: reviewable PRs keep governance and integration changes explicit and auditable.
+- What it affects: governance changes, workflow changes, journal additions, and repo-control-plane modifications.
+- What it explicitly does NOT affect: the repository reviewer's right to decide approval timing or merge order.
+- Follow-up needed: keep SI/governance changes scoped and reviewable.
+
+### DEC-system_integration_normalization-11
+- Status: locked
+- Decision: new components must enter the repo through the standard bootstrap path recorded in `contracts/repo/new_component_intake_standard_v1.md`.
+- Date context: component intake hardening phase
+- Why this was chosen: new component work needs one repeatable low-friction path that does not weaken branch or journal discipline.
+- What it affects: component creation, root paths, journals, and branch setup.
+- What it explicitly does NOT affect: later specialist work inside an already bootstrapped component.
+- Follow-up needed: use this standard for future component creation.
+
+### DEC-system_integration_normalization-12
+- Status: locked
+- Decision: low-click operation means bundling bootstrap setup into one clean PR while keeping `main` protected.
+- Date context: component intake hardening phase
+- Why this was chosen: the repository needs both strong control of truth and low operator overhead.
+- What it affects: how new-component setup work is packaged and presented for review.
+- What it explicitly does NOT affect: the need for later PRs when real component work continues.
+- Follow-up needed: keep bootstrap PRs bundled and concise.
+
+## Superseded Decisions
+- No individual locked decision is superseded in this v3 file.
+- The earlier v2 decision-log file remains a historical snapshot, while this v3 file becomes the current operating decision log.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v3.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v3.md
@@ -1,0 +1,151 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v3 file supersedes the earlier v2 snapshot as the current repo-facing SI/N status file.
+
+## 1. Scope
+- component name: system_integration_normalization
+- legacy names / aliases: SI/N, integration chat, normalization lane
+- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, cross-component integration policy, repo-native handoff quality, new-component intake discipline
+- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware feature implementation, source engine implementation
+
+## 2. Current Functional Status
+- what currently works:
+  - `main` holds the active governance, workflow, contract, and agent-onboarding control plane
+  - repo-driven deployment works through the current generic deploy/rollback workflow family on `main`
+  - Bridge deploy lane is operational from `dev/bridge`
+  - Bridge rollback unregisters the plugin and restarts Volumio
+  - active component journals exist in repo form for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+  - active component README hygiene and journal presence are CI-checked on `main`
+  - system integration now has repo-native governance, recovery, status, decisions, and stream material
+  - a standard new-component bootstrap path is now documented in repo form
+- what partially works:
+  - the process-doc extension in PR `#40` is open but not yet merged
+  - non-bridge deploy maturity is still uneven compared with Bridge
+  - some repo-truth cleanup is still active and not all older lower-value documents have been retired yet
+- what is broken:
+  - there is still no equally mature deploy/rollback proof across all active components
+  - not all agent entrypoint files can be updated through the current connector surface without lower-level git object handling
+- what was tested:
+  - Bridge deploy and rollback through the repo-driven workflow model on a real Pi
+  - wrapper-free repo-driven execution path
+  - active-component journal/README CI on `main`
+  - additive governance and journal writes through the GitHub connector path
+- what is untested:
+  - full generic deploy/rollback validation for every active component branch
+  - stronger CI enforcement for SI-specific recovery/onboarding and component-intake discipline
+
+## 3. Repository Mapping
+- correct component path in repo: `journals/system-integration-normalization/`
+- correct payload path(s): none
+- correct branch: `main` for truth; dedicated temporary working branches for repo-control-plane changes
+- whether component belongs on main or dev branch right now: main
+
+## 4. Locked Decisions
+### DEC-SIN-01
+- decision: `main` is the truth branch for workflows, governance, contracts, and accepted stable artifacts.
+- rationale: operator-visible execution and repo doctrine need one canonical source.
+- impact: workflows and governance live on `main`.
+
+### DEC-SIN-02
+- decision: active component work belongs on `dev/<component>` unless the component block is intentionally promoted to `main` truth.
+- rationale: separates unstable component work from the stable control plane.
+- impact: active component development remains on `dev/*` lanes unless governance says otherwise.
+
+### DEC-SIN-03
+- decision: deployment uses clean-replace semantics, not update-in-place.
+- rationale: current runtime maturity is still not strong enough for safe in-place mutation.
+- impact: deploy candidate scripts and workflow behavior remove/replace instead of patching live state.
+
+### DEC-SIN-04
+- decision: workflows must live on `main` and accept a selected `git_ref`.
+- rationale: manual operator-visible entrypoints must remain on the truth branch.
+- impact: deploy and rollback workflow families stay on `main`.
+
+### DEC-SIN-05
+- decision: the repo-shipped wrapper model is the accepted deployment entrypoint model.
+- rationale: stale Pi-local wrappers create drift and multi-host inconsistency.
+- impact: wrapper behavior is controlled from repo truth.
+
+### DEC-SIN-06
+- decision: rollback must unregister the plugin in Volumio when relevant.
+- rationale: file removal alone leaves operational residue.
+- impact: plugin rollback paths must clean runtime state and registration state.
+
+### DEC-SIN-07
+- decision: Bridge may remain inactive after install for now if runtime deployment, overlay reachability, and rollback are working.
+- rationale: current acceptance is based on proven runtime path and rollback reality.
+- impact: Bridge acceptance threshold remains pragmatic until activation behavior improves.
+
+### DEC-SIN-08
+- decision: governance doctrine belongs in `contracts/repo/`, while agent-facing onboarding and recovery material belongs in `docs/agents/` and must point back to governance and journals.
+- rationale: one governance home is needed, but agent recovery docs still need an explicit place.
+- impact: reduces future scattering of process truth across random repo paths.
+
+### DEC-SIN-09
+- decision: system integration must maintain repo-native status, decisions, and stream files.
+- rationale: SI/N governs the repo-control-plane and cannot depend on chat-only memory.
+- impact: SI/N now follows the same journal discipline expected from active components.
+
+### DEC-SIN-10
+- decision: new components must use the standard bootstrap path recorded in `contracts/repo/new_component_intake_standard_v1.md`.
+- rationale: future component creation needs one repeatable path that preserves branch and journal discipline.
+- impact: new-component setup now has a defined minimum structure and process.
+
+### DEC-SIN-11
+- decision: low-click operation means bundling bootstrap setup into one clean PR while keeping `main` protected.
+- rationale: the repo needs strong truth control without high review friction.
+- impact: new-component setup should be packaged as one concise bootstrap PR.
+
+## 5. Open Decisions
+- whether PR `#40` should merge as-is or receive follow-up refinement before merge
+- how strict the next SI-specific CI enforcement should become
+- whether older lower-value governance files should be removed or simply remain indexed as lower-precedence historical material
+- how quickly non-bridge deploy lanes should be normalized to the same maturity standard as Bridge
+
+## 6. Runtime / Deployment Notes
+- install assumptions:
+  - self-hosted Pi runner with labels matching workflow requirements
+  - repo checkout available during workflow run
+- uninstall / rollback assumptions:
+  - active runtime path can be moved aside
+  - Volumio restart and recovery check are required
+- services:
+  - `volumio`
+  - `volumio-kiosk`
+- configs:
+  - component-specific paths under `/data/configuration/...`
+  - Volumio plugin registration state in `/data/configuration/plugins.json`
+- ports:
+  - Bridge overlay has been validated on `:5511`
+- files / folders that matter:
+  - `.github/workflows/component-test-deploy-v6.yml`
+  - `.github/workflows/component-test-rollback-v6.yml`
+  - `tools/deploy/sr-deploy-wrapper.sh`
+  - `contracts/repo/`
+  - `journals/system-integration-normalization/`
+  - `docs/agents/`
+- dependencies:
+  - repo checkout on workflow runner
+  - active component branch/payload
+
+## 7. Known Risks
+- technical risks:
+  - non-bridge deploy lanes are still not equally proven
+  - some older governance material may still create noise until cleanup continues
+- integration risks:
+  - active `dev/<component>` branches drifting behind `main`
+  - repo truth being changed without matching journal/governance updates
+- rollback risks:
+  - only Bridge rollback is currently well-proven
+- handoff risks:
+  - recovery quality falls quickly if SI stream and onboarding docs stop being maintained
+
+## 8. Next Recommended Steps
+1. merge or finalize the process-doc layer currently represented by PR `#40`
+2. keep the SI stream updated for every meaningful repo-control-plane change
+3. decide whether SI recovery/onboarding and component-intake files should gain explicit CI enforcement
+4. continue normalizing deploy maturity beyond Bridge
+5. keep active component branches aligned to current `main` whenever practical
+
+## 9. Hand-off Notes
+A new specialist or integration chat should start from the governance index, onboarding file, SI status, SI decisions, SI stream, and then move into component-specific journals and open PR review.


### PR DESCRIPTION
Adds the next governance layer for introducing new components with low review effort while keeping `main` protected.

Included:
- `contracts/repo/new_component_intake_standard_v1.md`
- `contracts/repo/system_integration_governance_index_v2.md`
- `docs/agents/system_integration_recovery_onboarding_v2.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v3.md`
- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v3.md`

What this does:
- defines the standard bootstrap path for new components
- documents the minimum files, branch pattern, and communication rule for new component intake
- makes low-click but protected-`main` operation explicit in SI doctrine
- updates SI onboarding/read-order to point future chats to the new component intake standard
- records the new intake rule as current SI status and decision truth

Important note:
I also attempted to update `AGENTS.md` directly so the new standard would appear in the top-level agent entrypoint. The current GitHub connector surface supports additive file creation cleanly, but direct in-place update of existing files through this path requires metadata that is not exposed in the tool schema here. So the AGENTS update is not included in this PR.

Why this matters now:
- future chats need one repeatable way to create a new component stream on Git
- the repository needs to stay easy to review without weakening control of `main`
- new component work should no longer rely on chat memory or ad-hoc setup patterns
