### PR TITLE
Add remaining intake follow-up docs and AGENTS replacement notes

### DIFF
--- a/components/replace-ag.txt
+++ b/components/replace-ag.txt
@@ -1,0 +1,5 @@
+Replace `components/AGENTS.md` with the following addition under `## Component development rules`:
+- `bootstrap new components using contracts/repo/new_component_intake_standard_v2.md before adding payload structure`
+
+Optional clarification under `## Path discipline`:
+- `new component roots must use components/scale-radio-<component-suffix>/`

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v4.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v4.md
@@ -1,0 +1,35 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v4 file supersedes the earlier v3 snapshot as the current repo-facing SI/N decision log.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-10
+- Status: locked
+- Decision: new components must use the corrected bootstrap path recorded in `contracts/repo/new_component_intake_standard_v2.md`.
+- Date context: component intake hardening phase
+- Why this was chosen: future component creation needs one repeatable path that preserves branch, path, and journal discipline.
+- What it affects: component creation, root paths, journals, and branch setup.
+- What it explicitly does NOT affect: later specialist work inside an already bootstrapped component.
+- Follow-up needed: use this corrected standard for future component creation.
+
+### DEC-system_integration_normalization-11
+- Status: locked
+- Decision: low-click operation means bundling bootstrap setup into one clean PR while keeping `main` protected.
+- Date context: component intake hardening phase
+- Why this was chosen: the repo needs strong truth control without high review friction.
+- What it affects: how new-component setup work is packaged and presented for review.
+- What it explicitly does NOT affect: the need for later PRs when real component work continues.
+- Follow-up needed: keep bootstrap PRs bundled and concise.
+
+### DEC-system_integration_normalization-12
+- Status: locked
+- Decision: component root and journal paths use the full canonical component name, while the long-lived work branch uses the component suffix.
+- Date context: follow-up correction after path and branch ambiguity review
+- Why this was chosen: path naming and branch naming must each use one token consistently to avoid drift.
+- What it affects: component bootstrap paths and branch naming.
+- What it explicitly does NOT affect: existing governed component names already in canonical form.
+- Follow-up needed: keep future bootstrap docs aligned with this mapping.
+
+## Superseded Decisions
+- The earlier v3 decision-log file remains a historical snapshot, while this v4 file becomes the current intake-specific operating addendum.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v4.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v4.md
@@ -1,0 +1,23 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v4 file supersedes the earlier v3 snapshot as the current intake-specific SI/N status addendum.
+
+## Intake correction summary
+- canonical component root paths use the full governed component name
+- canonical journal paths use the full governed component name
+- long-lived work branches use the component suffix token
+- the corrected standard is `contracts/repo/new_component_intake_standard_v2.md`
+
+## Example mapping
+- component name: `scale-radio-bridge`
+- component root: `components/scale-radio-bridge/`
+- journals: `journals/scale-radio-bridge/`
+- work branch: `dev/bridge`
+
+## Current rule
+- new components should bootstrap through one bundled PR to protected `main`
+- after merge, ongoing work continues on `dev/<component-suffix>`
+- future chats should use the corrected standard and not the older ambiguous wording
+
+## Follow-up note
+This v4 status addendum exists because Codex correctly identified ambiguity in the earlier intake wording. The corrected standard and this status note remove that ambiguity for future component creation.

--- a/replace-ag.txt
+++ b/replace-ag.txt
@@ -1,0 +1,12 @@
+Replace `AGENTS.md` with the following updates:
+
+1. In `## Read first`, add these lines after `contracts/repo/repository_language_standard_v2.md`:
+- `contracts/repo/system_integration_governance_index_v3.md`
+- `contracts/repo/new_component_intake_standard_v2.md`
+- `docs/agents/system_integration_recovery_onboarding_v3.md`
+
+2. In `## Required behavior for agents`, add this line:
+- `bootstrap new components using contracts/repo/new_component_intake_standard_v2.md`
+
+3. In `## Skills and reference docs`, add this line:
+- `docs/agents/system_integration_recovery_onboarding_v3.md`


### PR DESCRIPTION
Adds the remaining follow-up files that did not make it into `main` when PR #42 was merged.

Included:
- `replace-ag.txt`
- `components/replace-ag.txt`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v4.md`
- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v4.md`

What this does:
- brings the manual AGENTS replacement notes onto `main`
- adds the intake-correction SI v4 addenda to repo truth
- makes the Codex-flagged path/branch correction explicitly available on `main`

Why this is separate:
- these files were added to the earlier intake branch after PR #42 had already been merged
- this PR is intentionally minimal and carries only the remaining follow-up files
