### PR TITLE
Align SI governance truth and add protected-main replacement-file operating model

### DIFF
--- a/.github/workflows/autonomous-delivery-orchestrator-v2.yml
+++ b/.github/workflows/autonomous-delivery-orchestrator-v2.yml
@@ -1,0 +1,129 @@
+name: autonomous-delivery-orchestrator-v2
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to deploy through the autonomous orchestrator"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component suffix, for example bridge"
+        required: true
+        default: "bridge"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  orchestrate_delivery:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dispatch supported autonomous delivery
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_GIT_REF: ${{ inputs.git_ref }}
+          INPUT_COMPONENT: ${{ inputs.component }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_TEST_HOLD_MINUTES: ${{ inputs.test_hold_minutes }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re, urllib.request
+          from pathlib import Path
+
+          repo = os.environ['GITHUB_REPOSITORY']
+          token = os.environ['GITHUB_TOKEN']
+          event_name = os.environ['EVENT_NAME']
+          pr_number = os.environ.get('PR_NUMBER') or ''
+          pr_head_ref = os.environ.get('PR_HEAD_REF') or ''
+          input_git_ref = os.environ.get('INPUT_GIT_REF') or ''
+          input_component = os.environ.get('INPUT_COMPONENT') or ''
+          input_target = os.environ.get('INPUT_TARGET') or 'primary'
+          input_test_hold_minutes = os.environ.get('INPUT_TEST_HOLD_MINUTES') or '240'
+          matrix = json.loads(Path('tools/governance/autonomous_delivery_matrix_v2.json').read_text(encoding='utf-8'))['components']
+          base = f'https://api.github.com/repos/{repo}'
+          headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'autonomous-delivery-orchestrator-v2'
+          }
+
+          def req(method, path, data=None):
+            body = None if data is None else json.dumps(data).encode('utf-8')
+            h = dict(headers)
+            if body is not None:
+              h['Content-Type'] = 'application/json'
+            r = urllib.request.Request(base + path, data=body, headers=h, method=method)
+            with urllib.request.urlopen(r) as resp:
+              raw = resp.read().decode('utf-8')
+              return json.loads(raw) if raw else None
+
+          def route_from_event():
+            if event_name == 'workflow_dispatch':
+              return input_component.strip(), input_git_ref.strip(), 'manual-dispatch'
+            m = re.fullmatch(r'dev/([a-z0-9-]+)', pr_head_ref.strip())
+            if m:
+              return m.group(1), pr_head_ref.strip(), 'merged-dev-branch'
+            return None, None, 'non-dev-pr-head'
+
+          component, git_ref, reason = route_from_event()
+          if not component or not git_ref:
+            print(f'skipped: {reason}')
+            raise SystemExit(0)
+
+          spec = matrix.get(component)
+          if not spec or not spec.get('auto_delivery_supported'):
+            title = f'Autonomous delivery skipped — {component}'
+            body = '\n'.join([
+              '# Autonomous delivery skipped',
+              '',
+              f'- component: `{component}`',
+              f'- git ref: `{git_ref}`',
+              f'- reason: `{spec.get("reason", "not in delivery matrix") if spec else "not in delivery matrix"}`',
+              '',
+              '## Required next step',
+              '- normalize deploy and rollback contracts before enabling autonomous delivery for this component',
+            ])
+            req('POST', '/issues', {'title': title, 'body': body, 'labels': ['governance','component:system-integration','agent:system-integration','type:integration-risk','impact:system-wide','state:ready-for-agent','source:manual']})
+            raise SystemExit(0)
+
+          payload = spec.get('default_payload', 'current_dev')
+          workflow = spec['deploy_workflow']
+          req('POST', f'/actions/workflows/{workflow}/dispatches', {'ref': 'main', 'inputs': {'git_ref': git_ref, 'component': component, 'payload': payload, 'target': input_target, 'test_hold_minutes': input_test_hold_minutes}})
+
+          if pr_number:
+            req('POST', f'/issues/{pr_number}/comments', {'body': '\n'.join([
+              '<!-- autonomous-delivery-orchestrator-v2 -->',
+              'Autonomous delivery dispatched.',
+              '',
+              f'- component: `{component}`',
+              f'- git ref: `{git_ref}`',
+              f'- payload: `{payload}`',
+              f'- target: `{input_target}`',
+              f'- source: `{reason}`',
+              '- target exclusivity is enforced by the deploy workflow on the Pi slot before runtime mutation.',
+            ])})
+          else:
+            print(f'dispatched component={component} git_ref={git_ref} payload={payload} target={input_target}')
+          PY

--- a/.github/workflows/component-test-deploy-v7.yml
+++ b/.github/workflows/component-test-deploy-v7.yml
@@ -1,0 +1,95 @@
+name: component-test-deploy-v7
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow/control-plane repository state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Acquire target deploy slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh acquire-deploy "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Apply selected payload via repo wrapper
+        id: apply_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Mark target slot as test_open
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh mark-test-open "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Roll back selected payload on failure
+        id: rollback_on_failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}"
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful failure rollback
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome == 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}" "deploy_failed_rollback_completed"
+
+      - name: Mark target slot blocked when deploy/rollback did not complete cleanly
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome != 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "deploy_or_failure_rollback_incomplete"

--- a/.github/workflows/component-test-release-slot-v1.yml
+++ b/.github/workflows/component-test-release-slot-v1.yml
@@ -1,0 +1,53 @@
+name: component-test-release-slot-v1
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      component:
+        description: "Component that currently owns the test slot"
+        required: true
+        default: "bridge"
+      git_ref:
+        description: "Git ref that currently owns the test slot"
+        required: true
+        default: "dev/bridge"
+      payload:
+        description: "Payload currently associated with the test slot"
+        required: true
+        default: "current_dev"
+      reason:
+        description: "Why the slot is being released"
+        required: true
+        default: "accepted_candidate"
+      force:
+        description: "Force release even if the recorded state does not match"
+        required: true
+        default: "false"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  release_target_slot:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          test -w /opt/scale-radio/state
+
+      - name: Release target test slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "release:${GITHUB_RUN_ID}" "${{ inputs.reason }}" "${{ inputs.force }}"

--- a/.github/workflows/component-test-rollback-v7.yml
+++ b/.github/workflows/component-test-rollback-v7.yml
@@ -1,0 +1,73 @@
+name: component-test-rollback-v7
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+
+      - name: Acquire target rollback slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}"
+
+      - name: Roll back selected payload via repo wrapper
+        id: rollback_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful rollback
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_completed"
+
+      - name: Mark target slot blocked on rollback failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v1.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_incomplete"

--- a/ag_new.txt
+++ b/ag_new.txt
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+## Purpose
+This file provides repository-wide operating instructions for coding agents working in this repo.
+
+## Read first
+Before touching files, read these governance documents on `main`:
+- `contracts/repo/branch_strategy_v2.md`
+- `contracts/repo/component_artifact_model_v1.md`
+- `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- `contracts/repo/release_intake_and_delivery_status_v2.md`
+- `contracts/repo/component_journal_policy_v2.md`
+- `contracts/repo/repository_language_standard_v2.md`
+- `contracts/repo/system_integration_governance_index_v5.md`
+- `contracts/repo/new_component_intake_standard_v2.md`
+- `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+- `docs/agents/system_integration_recovery_onboarding_v5.md`
+
+## Core doctrine
+- `main` is the canonical protected truth branch for workflows, governance, accepted stable artifacts, and operator-visible execution paths.
+- the repository remains public until further notice.
+- `dev/<component>` is the active component work lane.
+- `integration/staging` is an exception-only temporary integration-owned branch and not a second truth branch.
+- one component may contain multiple deployable artifacts/plugins.
+- do not split branches only because a component has multiple plugins.
+- Bridge is an overlay component and must be treated as such in docs, journals, deploy logic, and rollback logic.
+
+## Release and naming rules
+- follow `contracts/repo/naming_and_release_numbering_standard_v1.md`
+- mutable payload names are reserved: `current_dev`, `current`
+- new normalized immutable releases should use `vMAJOR.MINOR.PATCH`
+- do not invent new naming patterns without updating governance first
+
+## Documentation and journals
+- repository-facing content is English
+- journals, decisions, and streams are mandatory repo truth
+- update journals when deployment reality or component state changes materially
+- prefer factual current-state updates over narrative prose
+
+## Workflow doctrine
+- active deploy workflows live on `main`
+- current supported deploy lane is the v6 generic component workflow family unless newer governance supersedes it
+- do not reintroduce obsolete workflow generations
+- system integration should use short-lived repo-control-plane branches to `main` by default
+
+## CI doctrine
+- keep the repository free of Python cache artifacts
+- do not commit placeholder governance documents for active standards
+- shell scripts should remain syntax-clean under `bash -n`
+
+## Required behavior for agents
+- make repository changes in a dedicated non-`main` branch
+- keep changes scoped and governance-consistent
+- prefer component-level changes over ad-hoc plugin-fragment changes
+- if a new operational rule is introduced, put it into governance docs instead of relying on chat memory
+- bootstrap new components using `contracts/repo/new_component_intake_standard_v2.md`
+- if tooling, connector, access, or execution problems block safe completion, escalate and inform instead of improvising, faking completion, or silently creating partial truth
+- if a protected truth file cannot be safely mutated through the available connector surface, use the controlled replacement-file operating model instead of pretending the direct mutation succeeded
+
+## Skills and reference docs
+Agents should consult:
+- `docs/agents/skill_volumio4_plugin_development_v1.md`
+- `docs/agents/skill_overlay_component_governance_v1.md`
+- `docs/agents/reference_repositories_and_docs_v1.md`
+- `docs/agents/system_integration_recovery_onboarding_v5.md`

--- a/contracts/repo/deploy_target_exclusivity_standard_v1.md
+++ b/contracts/repo/deploy_target_exclusivity_standard_v1.md
@@ -1,0 +1,115 @@
+# DEPLOY TARGET EXCLUSIVITY STANDARD V1
+
+## Purpose
+This document defines the mandatory exclusivity rules for deploying, testing, accepting, and rolling back component candidates on a target Pi.
+
+## Leading rule
+One target Pi may have only one active deploy/test slot at a time.
+
+No other branch, workflow, chat, or agent may deploy to the same target while that slot is occupied.
+
+## Why this exists
+Without exclusivity:
+- one candidate can overwrite another during a test window
+- test observations become invalid
+- rollback anchors become ambiguous
+- owner review load increases because runtime truth becomes unclear
+
+## Target status model
+Each governed target Pi uses one of these statuses:
+- `free`
+- `deploying`
+- `test_open`
+- `rollback_running`
+- `blocked`
+
+## Status meaning
+### `free`
+The target is available for a new deploy/test run.
+
+### `deploying`
+A workflow has acquired the target and is actively deploying.
+No other deploy or rollback may begin.
+
+### `test_open`
+A deploy finished and the target is reserved for validation of that candidate.
+No other deploy may begin until the slot is released, rolled back, or times out.
+
+### `rollback_running`
+A rollback is actively in progress.
+No other deploy or rollback may begin.
+
+### `blocked`
+The target is in a manual-attention state because deploy, rollback, or lock handling did not complete cleanly.
+No other deploy may begin until the block is explicitly resolved.
+
+## Lock ownership rule
+A deploy/test slot records at least:
+- target identifier
+- component
+- git ref
+- payload
+- state
+- workflow/run owner marker
+- acquired timestamp
+- lease expiry when applicable
+
+## Timeout rule
+`deploying` and `test_open` may carry a lease timeout.
+If the timeout expires, a later workflow may reclaim the slot.
+
+Timeout is a recovery aid, not the preferred normal path.
+Normal completion should release the slot explicitly.
+
+## Allowed transitions
+- `free` -> `deploying`
+- `deploying` -> `test_open`
+- `deploying` -> `blocked`
+- `test_open` -> `rollback_running`
+- `test_open` -> `free`
+- `rollback_running` -> `free`
+- `rollback_running` -> `blocked`
+- `blocked` -> `rollback_running`
+- `blocked` -> `free` only through explicit governed release or recovery
+
+## Required workflow behavior
+### Deploy workflow
+A deploy workflow must:
+1. acquire the target slot before touching runtime state
+2. fail fast if the target is not `free` or safely reclaimable by timeout
+3. set the target to `deploying`
+4. set the target to `test_open` on successful deploy
+5. release or block the slot explicitly on failure
+
+### Rollback workflow
+A rollback workflow must:
+1. acquire the slot only from a compatible occupied state such as `test_open` or `blocked`
+2. set the target to `rollback_running`
+3. release the slot to `free` on successful rollback
+4. set the target to `blocked` on rollback failure
+
+### Test completion / acceptance release
+A governed release step must exist so the active test slot can be returned to `free` after:
+- acceptance of the tested candidate
+- explicit abandon of the test window
+- a governed manual release after inspection
+
+## Safety rule
+If the workflow cannot safely determine or mutate the target slot state:
+- do not deploy anyway
+- do not silently overwrite another active test window
+- escalate and inform
+
+## Starter exception
+Starter remains a separate normalization case.
+This contract governs target exclusivity and test integrity; it does not by itself make Starter deploy-ready.
+
+## Relation to stable/rollback baselines
+For non-Starter components:
+- repo truth is the leading truth before first real target deployment
+- a new stable/rollback anchor is declared only after branch deploy, target validation, and owner acceptance
+
+## What not to do
+- do not run parallel deploys on the same target
+- do not overwrite an occupied test window silently
+- do not treat a technically dispatchable workflow as permission to deploy when the target is reserved

--- a/contracts/repo/git_release_tagging_standard_v1.md
+++ b/contracts/repo/git_release_tagging_standard_v1.md
@@ -1,0 +1,62 @@
+# GIT RELEASE TAGGING STANDARD V1
+
+## Purpose
+This document defines the governed Git tagging rule for accepted stable baselines and rollback anchors.
+
+## Leading rule
+Git tags are not used for every intermediate branch state.
+Git tags are used only for accepted stable baselines and governed rollback anchors.
+
+## Why this exists
+This keeps repository history useful without turning tags into noise.
+It also makes stable recovery points obvious for owner review, rollback, and future agent work.
+
+## Tagging rule
+Create a Git tag only when a component baseline is:
+- accepted as stable after real validation, or
+- explicitly locked as the governed rollback anchor
+
+Do not create Git tags for:
+- every candidate deploy
+- every branch checkpoint
+- every PR merge
+- incomplete or unvalidated intermediate work
+
+## Tag format
+Use this format:
+- `<component-suffix>-vMAJOR.MINOR.PATCH`
+
+Examples:
+- `bridge-v1.2.3`
+- `tuner-v1.10.2`
+- `autoswitch-v0.3.0`
+
+## Relation to payload naming
+This standard does not replace the payload pointer model.
+The existing payload rules still apply:
+- `current_dev`
+- `current`
+- immutable payload releases using `vMAJOR.MINOR.PATCH`
+
+Git tags are the governed repository marker for accepted baselines, not the only naming mechanism.
+
+## When to tag
+Tag when all of these are true:
+1. the component baseline has a clear release number
+2. deploy/rollback contract is in governed repo truth
+3. real validation evidence exists at the intended acceptance level
+4. the baseline is accepted as stable or rollback-anchor truth
+5. journals and decisions are updated to match
+
+## What not to do
+- do not tag every experimental state
+- do not tag a baseline that has not been really validated at the intended level
+- do not create parallel tag naming schemes
+- do not use tags as a substitute for journals, decisions, or release handoff fields
+
+## Practical rule
+For most components, keep only the meaningful governed tags:
+- current accepted stable baseline
+- current rollback anchor when different from the stable baseline
+
+Older tags may remain for historical recovery, but new tagging should stay conservative.

--- a/contracts/repo/protected_main_truth_maintenance_operating_model_v1.md
+++ b/contracts/repo/protected_main_truth_maintenance_operating_model_v1.md
@@ -1,0 +1,46 @@
+# PROTECTED MAIN TRUTH MAINTENANCE OPERATING MODEL V1
+
+## Purpose
+This document defines the standard operating model for maintaining protected-`main` repo truth when an agent or connector cannot safely mutate an existing truth file directly.
+
+## Leading rule
+Do not improvise, fake completion, or silently create partial truth when safe mutation is blocked.
+
+If the normal branch-plus-PR path cannot safely update an existing truth file end-to-end, the agent must use the controlled replacement-file path and inform the owner.
+
+## Standard operating model
+### Default path
+Use the normal path whenever possible:
+1. update the target truth file on a working branch
+2. open a packaged PR to `main`
+3. owner reviews and merges
+
+### Replacement-file exception path
+If the connector or tool cannot safely mutate the existing truth file:
+1. create the intended replacement content on the working branch as a clearly named replacement file
+2. use a deterministic naming pattern such as:
+   - `ag_new.txt` for `AGENTS.md`
+   - `<target_basename>_new.txt` for similar truth-file replacements when appropriate
+3. explain in the PR body which protected truth file the replacement is for
+4. the owner manually applies the replacement to the protected truth file on `main`
+5. relevant journals and decision logs must record the operating-model use when it changes repo-truth maintenance behavior materially
+
+## Safety rule
+The replacement-file path is an exception path.
+It exists to preserve truth quality under tool limitations, not to bypass protected-`main` governance.
+
+## Communication rule
+When this path is used, the agent must state clearly:
+- what file could not be safely mutated
+- why the normal safe path was blocked
+- what replacement file was created
+- what owner action is required
+
+## Examples
+- top-level `AGENTS.md` cannot be safely updated through the current connector surface -> create `ag_new.txt` on the working branch and instruct the owner to apply it on `main`
+- another protected truth file cannot be safely mutated -> create a clearly named replacement artifact and document the required manual apply step
+
+## What not to do
+- do not claim the source truth file was updated when only a replacement artifact exists
+- do not open a PR that hides the fact that owner action is still required
+- do not fork a parallel governance chain just because a direct mutation path is awkward

--- a/contracts/repo/system_integration_governance_index_v5.md
+++ b/contracts/repo/system_integration_governance_index_v5.md
@@ -1,0 +1,40 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V5
+
+## Purpose
+This file is the current entrypoint for system integration governance, recovery, issue routing, autonomous execution doctrine, and the locked operating model for protected-`main` repo truth.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding and recovery material
+- `tools/governance/` = machine-readable governance support data used by workflows
+
+## Read order
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/new_component_intake_standard_v2.md`
+8. `contracts/repo/issue_governance_routing_standard_v1.md`
+9. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+10. `contracts/repo/system_integration_escalation_contract_v1.md`
+11. `docs/agents/system_integration_recovery_onboarding_v5.md`
+12. `journals/system-integration-normalization/STATUS_system_integration_normalization_v6.md`
+13. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v6.md`
+14. `journals/system-integration-normalization/stream_v1.md`
+
+## Locked operating model
+- the repository remains public until further notice
+- `main` remains the protected truth branch
+- agents and chats work on non-`main` branches
+- deploy/test happens from those branches
+- accepted work merges to `main` only after packaged review and owner acceptance
+- journals, decisions, and streams remain mandatory repo truth
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- new work intake, issue routing, escalation, and autonomous execution must use the governed repo model instead of ad-hoc chat memory
+- when tooling, connector, access, or other technical execution problems block safe completion, agents must escalate and inform instead of improvising or silently creating partial repo truth

--- a/contracts/repo/system_integration_governance_index_v6.md
+++ b/contracts/repo/system_integration_governance_index_v6.md
@@ -1,0 +1,44 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V6
+
+## Purpose
+This file is the current entrypoint for system integration governance, recovery, issue routing, autonomous execution doctrine, and the locked operating model for protected-`main` repo truth.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding and recovery material
+- `tools/governance/` = machine-readable governance support data used by workflows
+
+## Read order
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/new_component_intake_standard_v2.md`
+8. `contracts/repo/issue_governance_routing_standard_v1.md`
+9. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+10. `contracts/repo/system_integration_escalation_contract_v1.md`
+11. `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+12. `contracts/repo/deploy_target_exclusivity_standard_v1.md`
+13. `contracts/repo/truthful_execution_and_negative_answer_standard_v1.md`
+14. `contracts/repo/git_release_tagging_standard_v1.md`
+15. `docs/agents/system_integration_recovery_onboarding_v6.md`
+16. `journals/system-integration-normalization/STATUS_system_integration_normalization_v7.md`
+17. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+18. `journals/system-integration-normalization/stream_v5.md`
+
+## Locked operating model
+- the repository remains public until further notice
+- `main` remains the protected truth branch
+- agents and chats work on non-`main` branches
+- deploy/test happens from those branches
+- accepted work merges to `main` only after packaged review and owner acceptance
+- journals, decisions, and streams remain mandatory repo truth
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- new work intake, issue routing, escalation, and autonomous execution must use the governed repo model instead of ad-hoc chat memory
+- when tooling, connector, access, or other technical execution problems block safe completion, agents must escalate and inform instead of improvising or silently creating partial repo truth

--- a/contracts/repo/truthful_execution_and_negative_answer_standard_v1.md
+++ b/contracts/repo/truthful_execution_and_negative_answer_standard_v1.md
@@ -1,0 +1,50 @@
+# TRUTHFUL EXECUTION AND NEGATIVE ANSWER STANDARD V1
+
+## Purpose
+This document defines the mandatory truthfulness rule for governed repo work by chats, agents, and automation.
+
+## Leading rule
+An explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery.
+
+## Why this exists
+False completion is more dangerous than an explicit blocker because it:
+- corrupts repo truth
+- wastes owner review time
+- hides real technical limitations
+- creates invalid assumptions for later agents and workflows
+- makes test evidence and acceptance unreliable
+
+## Mandatory behavior
+When a chat, agent, or workflow cannot safely complete a requested action, it must:
+1. say that the action did not complete
+2. state the real blocker or limitation
+3. distinguish facts from assumptions
+4. avoid claiming repository or runtime changes that did not actually happen
+5. escalate and inform when the blocker affects repo truth, cross-component work, deploy/test integrity, or protected-main maintenance
+
+## Negative-answer rule
+A negative answer is the correct answer when:
+- the connector cannot safely mutate the target file
+- access is missing
+- the tool surface cannot perform the requested action
+- runtime validation did not happen
+- deploy or rollback could not be verified
+- a contract is not yet fulfilled
+- the result would otherwise be a placeholder or pretend-delivery
+
+## What not to do
+- do not say or imply that a file was updated when only a draft or replacement artifact exists
+- do not say or imply that deploy succeeded when only workflow dispatch was attempted
+- do not say or imply that runtime behavior is validated when no real target-Pi validation happened
+- do not hide uncertainty behind vague wording
+- do not substitute wishful thinking for repo truth
+
+## Relation to existing rules
+This standard complements:
+- protected-main truth maintenance
+- escalation on technical blockers
+- deploy target exclusivity
+- journal and decision freshness
+
+It does not weaken speed or autonomy.
+It defines the honesty boundary that keeps autonomous operation trustworthy.

--- a/docs/agents/system_integration_recovery_onboarding_v5.md
+++ b/docs/agents/system_integration_recovery_onboarding_v5.md
@@ -1,0 +1,127 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V5
+
+## Purpose
+This file is the fast re-entry and handover guide for a replacement system integration / normalization chat.
+
+## Current operating model
+The repository is an issue-driven, workflow-backed control plane.
+Use repo-native issues, labels, workflows, journals, and contracts as the operating system.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- issue routing and escalation discipline
+- autonomous execution guardrails
+- cross-component normalization
+- repo-truth cleanup where uncertainty still exists
+
+Do not assume deep specialist implementation ownership inside a component unless the repo state clearly requires it.
+
+## Current repo truth snapshot
+- repository: `SH99999/mediastreamer`
+- truth branch: `main`
+- repository visibility: public until further notice
+- active component branches:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- integration-owned exception branch:
+  - `integration/staging`
+- current governance layer includes:
+  - one-click branch rebase workflow
+  - weekly governance report issue workflow
+  - issue-governance routing automation
+  - governance closeout workflow
+  - autonomy/intake/escalation layer
+  - corrected issue-intake normalizer v2
+  - first live governance-loop validation already recorded
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v5.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_artifact_model_v1.md`
+5. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+6. `contracts/repo/release_intake_and_delivery_status_v2.md`
+7. `contracts/repo/component_journal_policy_v2.md`
+8. `contracts/repo/new_component_intake_standard_v2.md`
+9. `contracts/repo/issue_governance_routing_standard_v1.md`
+10. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+11. `contracts/repo/system_integration_escalation_contract_v1.md`
+12. `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+13. `journals/system-integration-normalization/STATUS_system_integration_normalization_v6.md`
+14. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v6.md`
+15. `journals/system-integration-normalization/stream_v2.md`
+16. active component journals under `journals/<component>/`
+
+## Locked operating rules
+- `main` is the protected truth branch and final owner acceptance gate
+- agents and chats work on non-`main` branches
+- deploy/test happens from the working branch
+- accepted work merges to `main` only after packaged review and owner acceptance
+- system integration uses short-lived repo-control-plane branches to `main` by default
+- `integration/staging` is exception-only for temporary integration-owned staging work
+- journals, decisions, and streams are mandatory repo truth and must not be treated as optional paperwork
+- if tooling, connector, access, or execution problems prevent safe completion, escalate and inform instead of improvising, faking completion, or silently mutating partial truth
+- if a connector cannot safely update an existing truth file, use the protected-main replacement-file operating model instead of forcing an unsafe mutation path
+
+## Key workflows to know immediately
+### Branch and repo health
+- `rebase-dev-and-integration-branches-on-main.yml`
+- `weekly-governance-report-issue.yml`
+- `release-readiness-audit.yml`
+- `repo-health-v3.yml`
+- `governance-health-v2.yml`
+- `component-health-v1.yml`
+
+### Issue governance and queue generation
+- `ensure-governance-labels.yml`
+- `open-decision-issues.yml`
+- `branch-drift-issues.yml`
+- `journal-freshness-issues.yml`
+- `stale-governance-items.yml`
+- `pr-governance-review.yml`
+- `governance-closeout.yml`
+
+### Intake and autonomy
+- `issue-intake-normalizer-v2.yml`
+- `issue-context-enrichment.yml`
+- `system-integration-escalation.yml`
+- `autonomous-delivery-orchestrator.yml`
+- `decision-verification-on-merge.yml`
+- `repo-control-plane-sanity-check.yml`
+- `bootstrap-new-component.yml`
+
+### Component deploy/test workflows still relevant
+- `component-test-deploy-v6.yml`
+- `component-test-rollback-v6.yml`
+
+## Working rule
+- use the issue-routing model instead of ad-hoc chat-side task memory
+- if work is cross-component or system-wide, escalate automatically to SI/governance
+- if a component is not support-matrix delivery-capable, do not pretend autonomous delivery support exists
+- keep repo-truth cleanup visible in docs, journals, and issues instead of hiding uncertainty
+
+## Current practical priorities
+1. keep the governance and issue control-plane working
+2. keep active branches aligned to `main`
+3. resolve repo-truth uncertainty where still open, highest priority:
+   - starter
+   - fun-line
+   - hardware
+4. keep component journals and decisions updated as active repo truth
+5. package repo-truth changes so owner review stays low-click
+
+## Minimum completion condition for a replacement SI chat
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what the current issue-routing model is
+- how escalation is triggered
+- which workflows are operator-facing versus background automation
+- which components are currently delivery-capable
+- which uncertainties are explicitly tracked in repo truth instead of assumed away
+- what to do when safe completion is blocked by tool or connector limitations

--- a/docs/agents/system_integration_recovery_onboarding_v6.md
+++ b/docs/agents/system_integration_recovery_onboarding_v6.md
@@ -1,0 +1,138 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V6
+
+## Purpose
+This file is the fast re-entry and handover guide for a replacement system integration / normalization chat.
+
+## Current operating model
+The repository is an issue-driven, workflow-backed control plane.
+Use repo-native issues, labels, workflows, journals, and contracts as the operating system.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- issue routing and escalation discipline
+- autonomous execution guardrails
+- cross-component normalization
+- repo-truth cleanup where uncertainty still exists
+
+Do not assume deep specialist implementation ownership inside a component unless the repo state clearly requires it.
+
+## Current repo truth snapshot
+- repository: `SH99999/mediastreamer`
+- truth branch: `main`
+- repository visibility: public until further notice
+- active component branches:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- integration-owned exception branch:
+  - `integration/staging`
+- current governance layer includes:
+  - one-click branch rebase workflow
+  - weekly governance report issue workflow
+  - issue-governance routing automation
+  - governance closeout workflow
+  - autonomy/intake/escalation layer
+  - corrected issue-intake normalizer v2
+  - first live governance-loop validation already recorded
+  - target deploy/test exclusivity governance and lock-aware workflows
+  - truthful execution and negative-answer standard
+  - governed Git release-tagging standard
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v6.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_artifact_model_v1.md`
+5. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+6. `contracts/repo/release_intake_and_delivery_status_v2.md`
+7. `contracts/repo/component_journal_policy_v2.md`
+8. `contracts/repo/new_component_intake_standard_v2.md`
+9. `contracts/repo/issue_governance_routing_standard_v1.md`
+10. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+11. `contracts/repo/system_integration_escalation_contract_v1.md`
+12. `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+13. `contracts/repo/deploy_target_exclusivity_standard_v1.md`
+14. `contracts/repo/truthful_execution_and_negative_answer_standard_v1.md`
+15. `contracts/repo/git_release_tagging_standard_v1.md`
+16. `journals/system-integration-normalization/STATUS_system_integration_normalization_v7.md`
+17. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+18. `journals/system-integration-normalization/stream_v5.md`
+19. active component journals under `journals/<component>/`
+
+## Locked operating rules
+- `main` is the protected truth branch and final owner acceptance gate
+- agents and chats work on non-`main` branches
+- deploy/test happens from the working branch
+- accepted work merges to `main` only after packaged review and owner acceptance
+- system integration uses short-lived repo-control-plane branches to `main` by default
+- `integration/staging` is exception-only for temporary integration-owned staging work
+- journals, decisions, and streams are mandatory repo truth and must not be treated as optional paperwork
+- if tooling, connector, access, or execution problems prevent safe completion, escalate and inform instead of improvising, faking completion, or silently mutating partial truth
+- if a connector cannot safely update an existing truth file, use the protected-main replacement-file operating model instead of forcing an unsafe mutation path
+- target deploy/test exclusivity is governed and must be respected before runtime mutation on the Pi
+- an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery
+
+## Key workflows to know immediately
+### Branch and repo health
+- `rebase-dev-and-integration-branches-on-main.yml`
+- `weekly-governance-report-issue.yml`
+- `release-readiness-audit.yml`
+- `repo-health-v3.yml`
+- `governance-health-v2.yml`
+- `component-health-v1.yml`
+
+### Issue governance and queue generation
+- `ensure-governance-labels.yml`
+- `open-decision-issues.yml`
+- `branch-drift-issues.yml`
+- `journal-freshness-issues.yml`
+- `stale-governance-items.yml`
+- `pr-governance-review.yml`
+- `governance-closeout.yml`
+
+### Intake and autonomy
+- `issue-intake-normalizer-v2.yml`
+- `issue-context-enrichment.yml`
+- `system-integration-escalation.yml`
+- `autonomous-delivery-orchestrator-v2.yml`
+- `decision-verification-on-merge.yml`
+- `repo-control-plane-sanity-check.yml`
+- `bootstrap-new-component.yml`
+
+### Component deploy/test workflows still relevant
+- `component-test-deploy-v7.yml`
+- `component-test-rollback-v7.yml`
+- `component-test-release-slot-v1.yml`
+
+## Working rule
+- use the issue-routing model instead of ad-hoc chat-side task memory
+- if work is cross-component or system-wide, escalate automatically to SI/governance
+- if a component is not support-matrix delivery-capable, do not pretend autonomous delivery support exists
+- keep repo-truth cleanup visible in docs, journals, and issues instead of hiding uncertainty
+
+## Current practical priorities
+1. keep the governance and issue control-plane working
+2. keep active branches aligned to `main`
+3. resolve repo-truth uncertainty where still open, highest priority:
+   - starter
+   - fun-line
+   - hardware
+4. keep component journals and decisions updated as active repo truth
+5. package repo-truth changes so owner review stays low-click
+6. validate the new lock-aware Bridge reference path on the real Pi
+
+## Minimum completion condition for a replacement SI chat
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what the current issue-routing model is
+- how escalation is triggered
+- which workflows are operator-facing versus background automation
+- which components are currently delivery-capable
+- which uncertainties are explicitly tracked in repo truth instead of assumed away
+- what to do when safe completion is blocked by tool or connector limitations
+- which stream file is the active SI stream truth

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v6.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v6.md
@@ -1,0 +1,89 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v6 file supersedes the earlier v5 autonomy-layer addendum as the current SI/N decision addendum.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-13
+- Status: locked
+- Decision: issue routing uses one central project plus label-based routing instead of one project per component or assignee-based agent routing.
+- Date context: governance routing phase
+- Why this was chosen: reduces owner admin overhead while staying automatable.
+- What it affects: issue routing, project usage, and agent-lane classification.
+- What it explicitly does NOT affect: optional human assignees for human ownership.
+- Follow-up needed: keep project views aligned with the label taxonomy.
+
+### DEC-system_integration_normalization-14
+- Status: locked
+- Decision: autonomous execution must minimize recurring owner administration and operate from repo truth.
+- Date context: autonomy layer definition phase
+- Why this was chosen: the owner should mainly take decisions, not perform repetitive system administration.
+- What it affects: workflow design, escalation behavior, and governance reporting.
+- What it explicitly does NOT affect: the owner's approval role on protected-main merges.
+- Follow-up needed: prefer automation over manual bookkeeping when safe.
+
+### DEC-system_integration_normalization-15
+- Status: locked
+- Decision: cross-component and system-wide impact must escalate automatically to system integration and governance.
+- Date context: autonomy layer definition phase
+- Why this was chosen: decisions that affect multiple lanes must not remain trapped in one chat or one component lane.
+- What it affects: issue routing, escalation workflows, and SI issue creation.
+- What it explicitly does NOT affect: component-local work with no cross-component effect.
+- Follow-up needed: keep escalation logic aligned with impact labels and governance docs.
+
+### DEC-system_integration_normalization-16
+- Status: locked
+- Decision: autonomous delivery must be support-matrix based and conservative.
+- Date context: autonomy layer definition phase
+- Why this was chosen: only components with normalized deploy and rollback contracts should auto-deliver.
+- What it affects: autonomous delivery behavior.
+- What it explicitly does NOT affect: future expansion of delivery support to more components once normalized.
+- Follow-up needed: update the delivery matrix when additional components become support-ready.
+
+### DEC-system_integration_normalization-17
+- Status: locked
+- Decision: UI/UX design standard and asset-placement work are first-class repo demands and must route through the same governance issue model as code or deployment work.
+- Date context: autonomy layer definition phase
+- Why this was chosen: non-code product work still affects the appliance and must not bypass repo governance.
+- What it affects: chat intake handling, issue routing, and UX-related escalation.
+- What it explicitly does NOT affect: whether the work is implemented by a code lane or a UX lane.
+- Follow-up needed: keep UX and asset work mapped into the issue-routing model.
+
+### DEC-system_integration_normalization-18
+- Status: locked
+- Decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- Date context: operating-model alignment phase
+- Why this was chosen: protected `main` preserves truth discipline while avoiding additional paid/private-repo overhead right now.
+- What it affects: repository visibility, review posture, and the public branch/PR operating model.
+- What it explicitly does NOT affect: a future visibility change if the cost/risk tradeoff changes later.
+- Follow-up needed: revisit only if the owner changes the visibility strategy.
+
+### DEC-system_integration_normalization-19
+- Status: locked
+- Decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- Date context: operating-model alignment phase
+- Why this was chosen: it minimizes branch clutter, truth ambiguity, and owner click overhead.
+- What it affects: SI branch usage and packaged PR behavior.
+- What it explicitly does NOT affect: specialist `dev/<component>` branches.
+- Follow-up needed: use `integration/staging` only for explicit temporary staging cases.
+
+### DEC-system_integration_normalization-20
+- Status: locked
+- Decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- Date context: operating-model alignment phase
+- Why this was chosen: explicit blockers are safer than false completion in a governed repo.
+- What it affects: all chat and Codex lanes, especially when technical execution is blocked.
+- What it explicitly does NOT affect: normal safe branch-plus-PR execution when the tools work.
+- Follow-up needed: route such blockers as integration-risk when they affect repo truth or cross-component work.
+
+### DEC-system_integration_normalization-21
+- Status: locked
+- Decision: if a connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- Date context: operating-model alignment phase
+- Why this was chosen: truth quality must survive tool limitations without pretending a direct mutation succeeded.
+- What it affects: maintenance of protected truth files such as `AGENTS.md`.
+- What it explicitly does NOT affect: the default expectation that truth changes should still use the normal branch-plus-PR path whenever possible.
+- Follow-up needed: use clearly named replacement artifacts such as `ag_new.txt` and state the required owner action explicitly.
+
+## Superseded Decisions
+- The earlier v5 decision addendum remains historical; this v6 file is the current SI alignment addendum.

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v7.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v7.md
@@ -1,0 +1,98 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v7 file supersedes the earlier v6 SI alignment addendum as the current SI/N decision addendum.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-13
+- Status: locked
+- Decision: issue routing uses one central project plus label-based routing instead of one project per component or assignee-based agent routing.
+- Date context: governance routing phase
+- Why this was chosen: reduces owner admin overhead while staying automatable.
+- What it affects: issue routing, project usage, and agent-lane classification.
+- What it explicitly does NOT affect: optional human assignees for human ownership.
+- Follow-up needed: keep project views aligned with the label taxonomy.
+
+### DEC-system_integration_normalization-14
+- Status: locked
+- Decision: autonomous execution must minimize recurring owner administration and operate from repo truth.
+- Date context: autonomy layer definition phase
+- Why this was chosen: the owner should mainly take decisions, not perform repetitive system administration.
+- What it affects: workflow design, escalation behavior, and governance reporting.
+- What it explicitly does NOT affect: the owner's approval role on protected-main merges.
+- Follow-up needed: prefer automation over manual bookkeeping when safe.
+
+### DEC-system_integration_normalization-15
+- Status: locked
+- Decision: cross-component and system-wide impact must escalate automatically to system integration and governance.
+- Date context: autonomy layer definition phase
+- Why this was chosen: decisions that affect multiple lanes must not remain trapped in one chat or one component lane.
+- What it affects: issue routing, escalation workflows, and SI issue creation.
+- What it explicitly does NOT affect: component-local work with no cross-component effect.
+- Follow-up needed: keep escalation logic aligned with impact labels and governance docs.
+
+### DEC-system_integration_normalization-16
+- Status: locked
+- Decision: autonomous delivery must be support-matrix based and conservative.
+- Date context: autonomy layer definition phase
+- Why this was chosen: only components with normalized deploy and rollback contracts should auto-deliver.
+- What it affects: autonomous delivery behavior.
+- What it explicitly does NOT affect: future expansion of delivery support to more components once normalized.
+- Follow-up needed: update the delivery matrix when additional components become support-ready.
+
+### DEC-system_integration_normalization-17
+- Status: locked
+- Decision: UI/UX design standard and asset-placement work are first-class repo demands and must route through the same governance issue model as code or deployment work.
+- Date context: autonomy layer definition phase
+- Why this was chosen: non-code product work still affects the appliance and must not bypass repo governance.
+- What it affects: chat intake handling, issue routing, and UX-related escalation.
+- What it explicitly does NOT affect: whether the work is implemented by a code lane or a UX lane.
+- Follow-up needed: keep UX and asset work mapped into the issue-routing model.
+
+### DEC-system_integration_normalization-18
+- Status: locked
+- Decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- Date context: operating-model alignment phase
+- Why this was chosen: protected `main` preserves truth discipline while avoiding additional paid/private-repo overhead right now.
+- What it affects: repository visibility, review posture, and the public branch/PR operating model.
+- What it explicitly does NOT affect: a future visibility change if the cost/risk tradeoff changes later.
+- Follow-up needed: revisit only if the owner changes the visibility strategy.
+
+### DEC-system_integration_normalization-19
+- Status: locked
+- Decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- Date context: operating-model alignment phase
+- Why this was chosen: it minimizes branch clutter, truth ambiguity, and owner click overhead.
+- What it affects: SI branch usage and packaged PR behavior.
+- What it explicitly does NOT affect: specialist `dev/<component>` branches.
+- Follow-up needed: use `integration/staging` only for explicit temporary staging cases.
+
+### DEC-system_integration_normalization-20
+- Status: locked
+- Decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- Date context: operating-model alignment phase
+- Why this was chosen: explicit blockers are safer than false completion in a governed repo.
+- What it affects: all chat and Codex lanes, especially when technical execution is blocked.
+- What it explicitly does NOT affect: normal safe branch-plus-PR execution when the tools work.
+- Follow-up needed: route such blockers as integration-risk when they affect repo truth or cross-component work.
+
+### DEC-system_integration_normalization-21
+- Status: locked
+- Decision: if a connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- Date context: operating-model alignment phase
+- Why this was chosen: truth quality must survive tool limitations without pretending a direct mutation succeeded.
+- What it affects: maintenance of protected truth files such as `AGENTS.md`.
+- What it explicitly does NOT affect: the default expectation that truth changes should still use the normal branch-plus-PR path whenever possible.
+- Follow-up needed: use clearly named replacement artifacts such as `ag_new.txt` and state the required owner action explicitly.
+
+### DEC-system_integration_normalization-22
+- Status: locked
+- Decision: one target Pi may have only one active deploy/test slot at a time, and workflows must refuse deployment when the target is already in a governed occupied state.
+- Date context: deploy-exclusivity alignment phase
+- Why this was chosen: parallel deploys invalidate tests and destroy confidence in rollback anchors.
+- What it affects: deploy, rollback, autonomous delivery dispatch, and all target-Pi validation behavior.
+- What it explicitly does NOT affect: the separate question of whether a component's deploy/rollback contract is mature enough to use the slot.
+- Follow-up needed: validate the new lock-aware workflow family with Bridge on the real Pi.
+
+## Superseded Decisions
+- The earlier v6 SI alignment addendum remains historical; this v7 file is the current deploy-exclusivity addendum.

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v8.md
@@ -1,0 +1,107 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v8 file supersedes the earlier v7 SI deploy-exclusivity addendum as the current SI/N decision addendum.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-13
+- Status: locked
+- Decision: issue routing uses one central project plus label-based routing instead of one project per component or assignee-based agent routing.
+- Date context: governance routing phase
+- Why this was chosen: reduces owner admin overhead while staying automatable.
+- What it affects: issue routing, project usage, and agent-lane classification.
+- What it explicitly does NOT affect: optional human assignees for human ownership.
+- Follow-up needed: keep project views aligned with the label taxonomy.
+
+### DEC-system_integration_normalization-14
+- Status: locked
+- Decision: autonomous execution must minimize recurring owner administration and operate from repo truth.
+- Date context: autonomy layer definition phase
+- Why this was chosen: the owner should mainly take decisions, not perform repetitive system administration.
+- What it affects: workflow design, escalation behavior, and governance reporting.
+- What it explicitly does NOT affect: the owner's approval role on protected-main merges.
+- Follow-up needed: prefer automation over manual bookkeeping when safe.
+
+### DEC-system_integration_normalization-15
+- Status: locked
+- Decision: cross-component and system-wide impact must escalate automatically to system integration and governance.
+- Date context: autonomy layer definition phase
+- Why this was chosen: decisions that affect multiple lanes must not remain trapped in one chat or one component lane.
+- What it affects: issue routing, escalation workflows, and SI issue creation.
+- What it explicitly does NOT affect: component-local work with no cross-component effect.
+- Follow-up needed: keep escalation logic aligned with impact labels and governance docs.
+
+### DEC-system_integration_normalization-16
+- Status: locked
+- Decision: autonomous delivery must be support-matrix based and conservative.
+- Date context: autonomy layer definition phase
+- Why this was chosen: only components with normalized deploy and rollback contracts should auto-deliver.
+- What it affects: autonomous delivery behavior.
+- What it explicitly does NOT affect: future expansion of delivery support to more components once normalized.
+- Follow-up needed: update the delivery matrix when additional components become support-ready.
+
+### DEC-system_integration_normalization-17
+- Status: locked
+- Decision: UI/UX design standard and asset-placement work are first-class repo demands and must route through the same governance issue model as code or deployment work.
+- Date context: autonomy layer definition phase
+- Why this was chosen: non-code product work still affects the appliance and must not bypass repo governance.
+- What it affects: chat intake handling, issue routing, and UX-related escalation.
+- What it explicitly does NOT affect: whether the work is implemented by a code lane or a UX lane.
+- Follow-up needed: keep UX and asset work mapped into the issue-routing model.
+
+### DEC-system_integration_normalization-18
+- Status: locked
+- Decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- Date context: operating-model alignment phase
+- Why this was chosen: protected `main` preserves truth discipline while avoiding additional paid/private-repo overhead right now.
+- What it affects: repository visibility, review posture, and the public branch/PR operating model.
+- What it explicitly does NOT affect: a future visibility change if the cost/risk tradeoff changes later.
+- Follow-up needed: revisit only if the owner changes the visibility strategy.
+
+### DEC-system_integration_normalization-19
+- Status: locked
+- Decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- Date context: operating-model alignment phase
+- Why this was chosen: it minimizes branch clutter, truth ambiguity, and owner click overhead.
+- What it affects: SI branch usage and packaged PR behavior.
+- What it explicitly does NOT affect: specialist `dev/<component>` branches.
+- Follow-up needed: use `integration/staging` only for explicit temporary staging cases.
+
+### DEC-system_integration_normalization-20
+- Status: locked
+- Decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- Date context: operating-model alignment phase
+- Why this was chosen: explicit blockers are safer than false completion in a governed repo.
+- What it affects: all chat and Codex lanes, especially when technical execution is blocked.
+- What it explicitly does NOT affect: normal safe branch-plus-PR execution when the tools work.
+- Follow-up needed: route such blockers as integration-risk when they affect repo truth or cross-component work.
+
+### DEC-system_integration_normalization-21
+- Status: locked
+- Decision: if a connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- Date context: operating-model alignment phase
+- Why this was chosen: truth quality must survive tool limitations without pretending a direct mutation succeeded.
+- What it affects: maintenance of protected truth files such as `AGENTS.md`.
+- What it explicitly does NOT affect: the default expectation that truth changes should still use the normal branch-plus-PR path whenever possible.
+- Follow-up needed: use clearly named replacement artifacts such as `ag_new.txt` and state the required owner action explicitly.
+
+### DEC-system_integration_normalization-22
+- Status: locked
+- Decision: one target Pi may have only one active deploy/test slot at a time, and workflows must refuse deployment when the target is already in a governed occupied state.
+- Date context: deploy-exclusivity alignment phase
+- Why this was chosen: parallel deploys invalidate tests and destroy confidence in rollback anchors.
+- What it affects: deploy, rollback, autonomous delivery dispatch, and all target-Pi validation behavior.
+- What it explicitly does NOT affect: the separate question of whether a component's deploy/rollback contract is mature enough to use the slot.
+- Follow-up needed: validate the new lock-aware workflow family with Bridge on the real Pi.
+
+### DEC-system_integration_normalization-23
+- Status: locked
+- Decision: an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery.
+- Date context: truthfulness alignment phase
+- Why this was chosen: repo truth and acceptance quality collapse when agents hide blockers or pretend work completed.
+- What it affects: all chats, Codex lanes, workflow reporting, repo-truth maintenance, and owner communication.
+- What it explicitly does NOT affect: the requirement to keep working autonomously when safe execution is actually possible.
+- Follow-up needed: keep this rule visible in governance and agent-facing operating docs.
+
+## Superseded Decisions
+- The earlier v7 SI deploy-exclusivity addendum remains historical; this v8 file is the current truthfulness-and-execution addendum.

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
@@ -1,0 +1,116 @@
+# DECISION LOG — system_integration_normalization
+
+Status note: this v9 file supersedes the earlier v8 truthfulness addendum as the current SI/N decision addendum.
+
+## Decision Entries
+
+### DEC-system_integration_normalization-13
+- Status: locked
+- Decision: issue routing uses one central project plus label-based routing instead of one project per component or assignee-based agent routing.
+- Date context: governance routing phase
+- Why this was chosen: reduces owner admin overhead while staying automatable.
+- What it affects: issue routing, project usage, and agent-lane classification.
+- What it explicitly does NOT affect: optional human assignees for human ownership.
+- Follow-up needed: keep project views aligned with the label taxonomy.
+
+### DEC-system_integration_normalization-14
+- Status: locked
+- Decision: autonomous execution must minimize recurring owner administration and operate from repo truth.
+- Date context: autonomy layer definition phase
+- Why this was chosen: the owner should mainly take decisions, not perform repetitive system administration.
+- What it affects: workflow design, escalation behavior, and governance reporting.
+- What it explicitly does NOT affect: the owner's approval role on protected-main merges.
+- Follow-up needed: prefer automation over manual bookkeeping when safe.
+
+### DEC-system_integration_normalization-15
+- Status: locked
+- Decision: cross-component and system-wide impact must escalate automatically to system integration and governance.
+- Date context: autonomy layer definition phase
+- Why this was chosen: decisions that affect multiple lanes must not remain trapped in one chat or one component lane.
+- What it affects: issue routing, escalation workflows, and SI issue creation.
+- What it explicitly does NOT affect: component-local work with no cross-component effect.
+- Follow-up needed: keep escalation logic aligned with impact labels and governance docs.
+
+### DEC-system_integration_normalization-16
+- Status: locked
+- Decision: autonomous delivery must be support-matrix based and conservative.
+- Date context: autonomy layer definition phase
+- Why this was chosen: only components with normalized deploy and rollback contracts should auto-deliver.
+- What it affects: autonomous delivery behavior.
+- What it explicitly does NOT affect: future expansion of delivery support to more components once normalized.
+- Follow-up needed: update the delivery matrix when additional components become support-ready.
+
+### DEC-system_integration_normalization-17
+- Status: locked
+- Decision: UI/UX design standard and asset-placement work are first-class repo demands and must route through the same governance issue model as code or deployment work.
+- Date context: autonomy layer definition phase
+- Why this was chosen: non-code product work still affects the appliance and must not bypass repo governance.
+- What it affects: chat intake handling, issue routing, and UX-related escalation.
+- What it explicitly does NOT affect: whether the work is implemented by a code lane or a UX lane.
+- Follow-up needed: keep UX and asset work mapped into the issue-routing model.
+
+### DEC-system_integration_normalization-18
+- Status: locked
+- Decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- Date context: operating-model alignment phase
+- Why this was chosen: protected `main` preserves truth discipline while avoiding additional paid/private-repo overhead right now.
+- What it affects: repository visibility, review posture, and the public branch/PR operating model.
+- What it explicitly does NOT affect: a future visibility change if the cost/risk tradeoff changes later.
+- Follow-up needed: revisit only if the owner changes the visibility strategy.
+
+### DEC-system_integration_normalization-19
+- Status: locked
+- Decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- Date context: operating-model alignment phase
+- Why this was chosen: it minimizes branch clutter, truth ambiguity, and owner click overhead.
+- What it affects: SI branch usage and packaged PR behavior.
+- What it explicitly does NOT affect: specialist `dev/<component>` branches.
+- Follow-up needed: use `integration/staging` only for explicit temporary staging cases.
+
+### DEC-system_integration_normalization-20
+- Status: locked
+- Decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- Date context: operating-model alignment phase
+- Why this was chosen: explicit blockers are safer than false completion in a governed repo.
+- What it affects: all chat and Codex lanes, especially when technical execution is blocked.
+- What it explicitly does NOT affect: normal safe branch-plus-PR execution when the tools work.
+- Follow-up needed: route such blockers as integration-risk when they affect repo truth or cross-component work.
+
+### DEC-system_integration_normalization-21
+- Status: locked
+- Decision: if a connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- Date context: operating-model alignment phase
+- Why this was chosen: truth quality must survive tool limitations without pretending a direct mutation succeeded.
+- What it affects: maintenance of protected truth files such as `AGENTS.md`.
+- What it explicitly does NOT affect: the default expectation that truth changes should still use the normal branch-plus-PR path whenever possible.
+- Follow-up needed: use clearly named replacement artifacts such as `ag_new.txt` and state the required owner action explicitly.
+
+### DEC-system_integration_normalization-22
+- Status: locked
+- Decision: one target Pi may have only one active deploy/test slot at a time, and workflows must refuse deployment when the target is already in a governed occupied state.
+- Date context: deploy-exclusivity alignment phase
+- Why this was chosen: parallel deploys invalidate tests and destroy confidence in rollback anchors.
+- What it affects: deploy, rollback, autonomous delivery dispatch, and all target-Pi validation behavior.
+- What it explicitly does NOT affect: the separate question of whether a component's deploy/rollback contract is mature enough to use the slot.
+- Follow-up needed: validate the new lock-aware workflow family with Bridge on the real Pi.
+
+### DEC-system_integration_normalization-23
+- Status: locked
+- Decision: an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery.
+- Date context: truthfulness alignment phase
+- Why this was chosen: repo truth and acceptance quality collapse when agents hide blockers or pretend work completed.
+- What it affects: all chats, Codex lanes, workflow reporting, repo-truth maintenance, and owner communication.
+- What it explicitly does NOT affect: the requirement to keep working autonomously when safe execution is actually possible.
+- Follow-up needed: keep this rule visible in governance and agent-facing operating docs.
+
+### DEC-system_integration_normalization-24
+- Status: locked
+- Decision: Git tags are created only for accepted stable baselines and governed rollback anchors, using the format `<component-suffix>-vMAJOR.MINOR.PATCH`.
+- Date context: release-tagging alignment phase
+- Why this was chosen: meaningful tags improve recovery and review, while tagging every intermediate state creates noise and weakens trust in tags.
+- What it affects: Git tagging practice, stable baseline marking, and rollback anchor discoverability.
+- What it explicitly does NOT affect: payload pointer names such as `current_dev` and `current`, or the requirement to keep journals and release handoff fields up to date.
+- Follow-up needed: add tags conservatively only when a baseline is actually accepted or locked as rollback truth.
+
+## Superseded Decisions
+- The earlier v8 truthfulness addendum remains historical; this v9 file is the current release-tagging addendum.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v6.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v6.md
@@ -1,0 +1,98 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v6 file supersedes the earlier v5 autonomy-layer snapshot as the current SI/N status addendum.
+
+## 1. Scope
+- component name: system_integration_normalization
+- legacy names / aliases: SI/N, integration chat, normalization lane
+- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, issue routing, escalation discipline, autonomous execution guardrails, cross-component normalization, protected-main truth maintenance operating model
+- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware implementation, unsupported component delivery automation
+
+## 2. Current Functional Status
+- what currently works:
+  - governance, issue-routing, and reporting workflows exist on `main`
+  - one-click branch rebase exists for all current and future `dev/*` and `integration/*` branches
+  - weekly governance report issues are generated from repo truth
+  - open decisions, branch drift, and journal freshness can become governance-routed issues automatically
+  - PR governance review and governance closeout workflows are active
+  - new governed components can be bootstrapped via workflow
+  - release-readiness audit exists as a manual gate
+  - an autonomous execution doctrine and SI escalation contract exist in repo form
+  - a protected-main truth maintenance operating model now exists for safe handling of connector mutation limits
+- what partially works:
+  - autonomous delivery is still support-matrix limited and not yet broad across all active components
+  - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts such as `ag_new.txt` may still be required
+  - AGENTS pointer-chain alignment still requires owner application on `main`
+- what is broken:
+  - unsupported components cannot yet use autonomous delivery and must still escalate or no-op safely
+- what was tested:
+  - governance reporting and routing layers were merged and are available on `main`
+  - project auto-add and project views were confirmed to work with the governance label model
+  - branch creation and new-file repo-truth updates through the connector are working
+- what is untested:
+  - broader autonomous delivery beyond the current support matrix
+  - a future connector path for safe in-place mutation of all protected truth files
+
+## 3. Repository Mapping
+- correct component path in repo: `journals/system-integration-normalization/`
+- correct truth contracts: `contracts/repo/`
+- correct support data path: `tools/governance/`
+- correct branch model: `main` for truth; short-lived repo-control-plane branches for SI changes; `integration/staging` as an exception-only branch
+
+## 4. Locked Decisions
+### DEC-SIN-12
+- decision: issue routing is label-based and one central GitHub Project is used instead of one project per component.
+- rationale: low owner overhead and scalable routing.
+- impact: governance issues route by label, not by assignee.
+
+### DEC-SIN-13
+- decision: autonomous execution must minimize recurring owner administration and use governed repo workflows and repo truth.
+- rationale: the repo is becoming the operating system for the project.
+- impact: workflows and docs must favor auto-routing, auto-reporting, and safe escalation.
+
+### DEC-SIN-14
+- decision: cross-component and system-wide impact must escalate automatically to system integration / governance.
+- rationale: chat memory is not a safe integration bus.
+- impact: escalation workflows and labels are required.
+
+### DEC-SIN-15
+- decision: autonomous delivery must be support-matrix based and conservative.
+- rationale: not all components have normalized deploy/rollback contracts yet.
+- impact: unsupported components must escalate or no-op safely instead of pretending delivery support exists.
+
+### DEC-SIN-16
+- decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- rationale: low-cost operation is currently preferred over private-repo administration while protected `main` still preserves truth discipline.
+- impact: work happens in public branches and PRs; accepted truth still gates on protected `main`.
+
+### DEC-SIN-17
+- decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- rationale: this minimizes branch clutter, truth ambiguity, and owner click overhead.
+- impact: SI changes should normally ship as packaged PRs from temporary branches.
+
+### DEC-SIN-18
+- decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- rationale: false completion is more dangerous than an explicit blocker in a governed repo.
+- impact: blocking technical issues become visible repo/integration risks instead of hidden drift.
+
+### DEC-SIN-19
+- decision: if the connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- rationale: protected truth must remain accurate even when the mutation surface is limited.
+- impact: replacement artifacts such as `ag_new.txt` are allowed as an exception path when clearly documented.
+
+## 5. Open Decisions
+- when additional components become delivery-capable in the autonomous support matrix
+- whether the repository should later move to private visibility if the cost/risk tradeoff changes
+- whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
+
+## 6. Runtime / Deployment Notes
+- current autonomous delivery-capable component: Bridge
+- delivery support matrix path: `tools/governance/autonomous_delivery_matrix_v1.json`
+- unsupported components must not auto-deliver until their contracts are normalized
+- owner remains the final onsite acceptance gate before stable truth is merged to `main`
+
+## 7. Next Recommended Steps
+1. align `AGENTS.md` on `main` using the `ag_new.txt` replacement artifact
+2. review and merge this SI alignment package
+3. keep incoming component PRs aligned to the locked public/protected-main operating model
+4. continue component deploy/rollback normalization beyond Bridge

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v7.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v7.md
@@ -1,0 +1,107 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v7 file supersedes the earlier v6 SI alignment snapshot as the current SI/N status addendum.
+
+## 1. Scope
+- component name: system_integration_normalization
+- legacy names / aliases: SI/N, integration chat, normalization lane
+- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, issue routing, escalation discipline, autonomous execution guardrails, cross-component normalization, protected-main truth maintenance operating model, target deploy/test exclusivity rules
+- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware implementation, unsupported component delivery automation
+
+## 2. Current Functional Status
+- what currently works:
+  - governance, issue-routing, and reporting workflows exist on `main`
+  - one-click branch rebase exists for all current and future `dev/*` and `integration/*` branches
+  - weekly governance report issues are generated from repo truth
+  - open decisions, branch drift, and journal freshness can become governance-routed issues automatically
+  - PR governance review and governance closeout workflows are active
+  - new governed components can be bootstrapped via workflow
+  - release-readiness audit exists as a manual gate
+  - an autonomous execution doctrine and SI escalation contract exist in repo form
+  - a protected-main truth maintenance operating model exists for safe handling of connector mutation limits
+  - a target deploy/test exclusivity contract and lock-aware workflow set now exist on the SI alignment branch
+- what partially works:
+  - autonomous delivery is still support-matrix limited and not yet broad across all active components
+  - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts such as `ag_new.txt` may still be required
+  - `AGENTS.md` pointer-chain alignment still requires owner application on `main`
+  - the generic deploy wrapper still only supports Bridge directly, so target exclusivity is now governed but multi-component runtime deployment still needs component-by-component wrapper normalization
+- what is broken:
+  - unsupported components cannot yet use autonomous delivery and must still escalate or no-op safely
+- what was tested:
+  - governance reporting and routing layers were merged and are available on `main`
+  - project auto-add and project views were confirmed to work with the governance label model
+  - branch creation and new-file repo-truth updates through the connector are working
+- what is untested:
+  - broader autonomous delivery beyond the current support matrix
+  - the new lock-aware deploy/rollback workflow family on the target Pi
+  - a future connector path for safe in-place mutation of all protected truth files
+
+## 3. Repository Mapping
+- correct component path in repo: `journals/system-integration-normalization/`
+- correct truth contracts: `contracts/repo/`
+- correct support data path: `tools/governance/`
+- correct branch model: `main` for truth; short-lived repo-control-plane branches for SI changes; `integration/staging` as an exception-only branch
+
+## 4. Locked Decisions
+### DEC-SIN-12
+- decision: issue routing is label-based and one central GitHub Project is used instead of one project per component.
+- rationale: low owner overhead and scalable routing.
+- impact: governance issues route by label, not by assignee.
+
+### DEC-SIN-13
+- decision: autonomous execution must minimize recurring owner administration and use governed repo workflows and repo truth.
+- rationale: the repo is becoming the operating system for the project.
+- impact: workflows and docs must favor auto-routing, auto-reporting, and safe escalation.
+
+### DEC-SIN-14
+- decision: cross-component and system-wide impact must escalate automatically to system integration / governance.
+- rationale: chat memory is not a safe integration bus.
+- impact: escalation workflows and labels are required.
+
+### DEC-SIN-15
+- decision: autonomous delivery must be support-matrix based and conservative.
+- rationale: not all components have normalized deploy/rollback contracts yet.
+- impact: unsupported components must escalate or no-op safely instead of pretending delivery support exists.
+
+### DEC-SIN-16
+- decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- rationale: low-cost operation is currently preferred over private-repo administration while protected `main` still preserves truth discipline.
+- impact: work happens in public branches and PRs; accepted truth still gates on protected `main`.
+
+### DEC-SIN-17
+- decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- rationale: this minimizes branch clutter, truth ambiguity, and owner click overhead.
+- impact: SI changes should normally ship as packaged PRs from temporary branches.
+
+### DEC-SIN-18
+- decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- rationale: false completion is more dangerous than an explicit blocker in a governed repo.
+- impact: blocking technical issues become visible repo/integration risks instead of hidden drift.
+
+### DEC-SIN-19
+- decision: if the connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- rationale: protected truth must remain accurate even when the mutation surface is limited.
+- impact: replacement artifacts such as `ag_new.txt` are allowed as an exception path when clearly documented.
+
+### DEC-SIN-20
+- decision: one target Pi may have only one active deploy/test slot at a time; no other deploy may run while that slot is occupied.
+- rationale: parallel deploys destroy test validity and make rollback anchors ambiguous.
+- impact: deploy/test/rollback workflows must respect target-slot state such as `free`, `deploying`, `test_open`, `rollback_running`, and `blocked`.
+
+## 5. Open Decisions
+- when additional components become delivery-capable in the autonomous support matrix
+- whether the repository should later move to private visibility if the cost/risk tradeoff changes
+- whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
+
+## 6. Runtime / Deployment Notes
+- current autonomous delivery-capable component: Bridge
+- delivery support matrix path on the new workflow lane: `tools/governance/autonomous_delivery_matrix_v2.json`
+- unsupported components must not auto-deliver until their contracts are normalized
+- owner remains the final onsite acceptance gate before stable truth is merged to `main`
+- target exclusivity and lock handling do not by themselves make non-Bridge components deploy-ready while the wrapper remains Bridge-only
+
+## 7. Next Recommended Steps
+1. align `AGENTS.md` on `main` using the `ag_new.txt` replacement artifact
+2. review and merge this SI alignment package
+3. validate the new target-slot lock workflows on the Pi with Bridge
+4. then normalize the next component wrapper contract after Bridge proves the slot model

--- a/journals/system-integration-normalization/stream_v2.md
+++ b/journals/system-integration-normalization/stream_v2.md
@@ -1,0 +1,106 @@
+# STREAM — system_integration_normalization
+
+Status note: this v2 file supersedes `stream_v1.md` as the current SI/N stream because the original file became stale and could not be cleanly updated through the normal connector mutation path without creating ambiguity.
+
+## Entries
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 / main / PR #31 merged
+- branch doctrine, component artifact model, and naming/release numbering standards were added
+- purpose: stop recurring branch and multi-artifact ambiguity
+
+### 2026-04-13 / main / PR #32 merged
+- repo-level agent onboarding files and skills were added
+- purpose: reduce repeated context rebuilding for future agent work
+
+### 2026-04-13 / main / PR #33 merged
+- canonical governance source precedence and overlay contract docs were added
+- purpose: reduce doctrine conflicts and give overlay behavior a formal governance home
+
+### 2026-04-13 / main / PR #35 merged
+- governance CI wording was corrected after a brittle text-match failure
+- purpose: keep governance checks usable against real repo wording
+
+### 2026-04-13 / main / PR #36 merged
+- initial component current-state and stream journals were added for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+- purpose: move active component handoff memory into repo-native journals
+
+### 2026-04-13 / main / PR #37 merged
+- missing tuner current-state journal gap was closed
+- purpose: restore journal completeness for active components
+
+### 2026-04-13 / main / PR #38 merged
+- stub component READMEs were replaced with short governed component overviews
+- purpose: improve human and agent pickup quality at component roots
+
+### 2026-04-13 / main / PR #39 merged
+- CI checks for active component journals and READMEs were added
+- purpose: turn journal discipline into repo-enforced hygiene
+
+### 2026-04-14 / main / PR #40 merged
+- process docs for technology changes, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence were added
+- purpose: normalize liveable interdependency handling and active review discipline
+
+### 2026-04-14 / main / PR #41 merged
+- SI recovery onboarding and continuity docs were added
+- purpose: reduce chat-loss risk and keep SI/N operating memory inside Git
+
+### 2026-04-14 / main / PR #42 merged
+- corrected new-component intake governance and SI doctrine updates were added
+- purpose: make new component bootstrap repeatable and repo-native
+
+### 2026-04-14 / main / PR #43 merged
+- remaining intake follow-up docs and AGENTS replacement notes were added
+- purpose: close gaps left behind by the earlier intake merge sequence
+
+### 2026-04-14 / main / PR #44 merged
+- AGENTS references were updated
+- purpose: reduce stale onboarding pointers
+
+### 2026-04-14 / main / PR #46 merged
+- old AGENTS bootstrap wording was removed
+- purpose: avoid pointing future chats at outdated intake behavior
+
+### 2026-04-14 / main / PR #48 merged
+- one-click rebase workflow for `dev/*` and `integration/*` branches was added
+- purpose: reduce manual branch alignment work
+
+### 2026-04-14 / main / PR #50 merged
+- weekly governance report issue workflow was added
+- purpose: create a repo-native recurring oversight loop
+
+### 2026-04-14 / main / PR #52 merged
+- issue governance routing and automation workflows were added
+- purpose: turn repo truth into a managed operating queue
+
+### 2026-04-14 / main / PR #53 merged
+- governance closeout workflow was added
+- purpose: close the issue loop after merges
+
+### 2026-04-14 / main / PR #55 merged
+- autonomy layer, escalation workflows, and repo sanity controls were added
+- purpose: move toward lower-admin autonomous execution from repo truth
+
+### 2026-04-14 / main / PR #57 and PR #58 merged
+- intake and PR routing behavior was corrected
+- purpose: keep label-driven automation responsive to real events
+
+### 2026-04-14 / main / PR #60 merged
+- corrected issue-intake normalizer v2 was added
+- purpose: unblock the first live governance-loop validation
+
+### 2026-04-14 / main / PR #61 merged
+- first live governance-loop validation was recorded
+- purpose: confirm the governed demand path is active in repo truth
+
+### 2026-04-14 / si-alignment-v1 / current branch
+- SI governance index v5 was added
+- protected-main truth maintenance operating model was added
+- SI recovery onboarding v5 was added
+- SI status v6 and decisions v6 were added
+- this v2 stream was created because the original `stream_v1.md` became stale and direct safe mutation remained awkward through the connector surface
+- an `ag_new.txt` replacement artifact was prepared for owner application to `AGENTS.md` on `main`
+- purpose: align SI repo truth to the locked operating model without pretending direct protected-truth mutation worked when it did not

--- a/journals/system-integration-normalization/stream_v3.md
+++ b/journals/system-integration-normalization/stream_v3.md
@@ -1,0 +1,112 @@
+# STREAM — system_integration_normalization
+
+Status note: this v3 file supersedes `stream_v2.md` as the current SI/N stream because target deploy/test exclusivity and lock-aware workflow alignment materially changed the operating model after the earlier v2 alignment snapshot.
+
+## Entries
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 / main / PR #31 merged
+- branch doctrine, component artifact model, and naming/release numbering standards were added
+- purpose: stop recurring branch and multi-artifact ambiguity
+
+### 2026-04-13 / main / PR #32 merged
+- repo-level agent onboarding files and skills were added
+- purpose: reduce repeated context rebuilding for future agent work
+
+### 2026-04-13 / main / PR #33 merged
+- canonical governance source precedence and overlay contract docs were added
+- purpose: reduce doctrine conflicts and give overlay behavior a formal governance home
+
+### 2026-04-13 / main / PR #35 merged
+- governance CI wording was corrected after a brittle text-match failure
+- purpose: keep governance checks usable against real repo wording
+
+### 2026-04-13 / main / PR #36 merged
+- initial component current-state and stream journals were added for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+- purpose: move active component handoff memory into repo-native journals
+
+### 2026-04-13 / main / PR #37 merged
+- missing tuner current-state journal gap was closed
+- purpose: restore journal completeness for active components
+
+### 2026-04-13 / main / PR #38 merged
+- stub component READMEs were replaced with short governed component overviews
+- purpose: improve human and agent pickup quality at component roots
+
+### 2026-04-13 / main / PR #39 merged
+- CI checks for active component journals and READMEs were added
+- purpose: turn journal discipline into repo-enforced hygiene
+
+### 2026-04-14 / main / PR #40 merged
+- process docs for technology changes, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence were added
+- purpose: normalize liveable interdependency handling and active review discipline
+
+### 2026-04-14 / main / PR #41 merged
+- SI recovery onboarding and continuity docs were added
+- purpose: reduce chat-loss risk and keep SI/N operating memory inside Git
+
+### 2026-04-14 / main / PR #42 merged
+- corrected new-component intake governance and SI doctrine updates were added
+- purpose: make new component bootstrap repeatable and repo-native
+
+### 2026-04-14 / main / PR #43 merged
+- remaining intake follow-up docs and AGENTS replacement notes were added
+- purpose: close gaps left behind by the earlier intake merge sequence
+
+### 2026-04-14 / main / PR #44 merged
+- AGENTS references were updated
+- purpose: reduce stale onboarding pointers
+
+### 2026-04-14 / main / PR #46 merged
+- old AGENTS bootstrap wording was removed
+- purpose: avoid pointing future chats at outdated intake behavior
+
+### 2026-04-14 / main / PR #48 merged
+- one-click rebase workflow for `dev/*` and `integration/*` branches was added
+- purpose: reduce manual branch alignment work
+
+### 2026-04-14 / main / PR #50 merged
+- weekly governance report issue workflow was added
+- purpose: create a repo-native recurring oversight loop
+
+### 2026-04-14 / main / PR #52 merged
+- issue governance routing and automation workflows were added
+- purpose: turn repo truth into a managed operating queue
+
+### 2026-04-14 / main / PR #53 merged
+- governance closeout workflow was added
+- purpose: close the issue loop after merges
+
+### 2026-04-14 / main / PR #55 merged
+- autonomy layer, escalation workflows, and repo sanity controls were added
+- purpose: move toward lower-admin autonomous execution from repo truth
+
+### 2026-04-14 / main / PR #57 and PR #58 merged
+- intake and PR routing behavior was corrected
+- purpose: keep label-driven automation responsive to real events
+
+### 2026-04-14 / main / PR #60 merged
+- corrected issue-intake normalizer v2 was added
+- purpose: unblock the first live governance-loop validation
+
+### 2026-04-14 / main / PR #61 merged
+- first live governance-loop validation was recorded
+- purpose: confirm the governed demand path is active in repo truth
+
+### 2026-04-14 / si-alignment-v1 / current branch
+- SI governance index v5 was added
+- protected-main truth maintenance operating model was added
+- SI recovery onboarding v5 was added
+- SI status v6 and decisions v6 were added
+- stream v2 and `ag_new.txt` were created to align protected-main SI truth under connector mutation limits
+- purpose: align SI repo truth to the locked public/protected-main operating model
+
+### 2026-04-14 / si-alignment-v1 / current branch / deploy exclusivity follow-up
+- deploy target exclusivity standard was added
+- lock-aware deploy, rollback, explicit release, and autonomous orchestrator workflow generations were added
+- the Pi target state model `free`, `deploying`, `test_open`, `rollback_running`, and `blocked` was locked as repo truth
+- SI status v7 and decisions v7 were added
+- purpose: prevent overlapping deploy/test windows on the same target Pi and preserve valid runtime acceptance evidence

--- a/journals/system-integration-normalization/stream_v4.md
+++ b/journals/system-integration-normalization/stream_v4.md
@@ -1,0 +1,117 @@
+# STREAM — system_integration_normalization
+
+Status note: this v4 file supersedes `stream_v3.md` as the current SI/N stream because the truthfulness-and-negative-answer rule materially changed the governed execution model after the deploy-exclusivity alignment.
+
+## Entries
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 / main / PR #31 merged
+- branch doctrine, component artifact model, and naming/release numbering standards were added
+- purpose: stop recurring branch and multi-artifact ambiguity
+
+### 2026-04-13 / main / PR #32 merged
+- repo-level agent onboarding files and skills were added
+- purpose: reduce repeated context rebuilding for future agent work
+
+### 2026-04-13 / main / PR #33 merged
+- canonical governance source precedence and overlay contract docs were added
+- purpose: reduce doctrine conflicts and give overlay behavior a formal governance home
+
+### 2026-04-13 / main / PR #35 merged
+- governance CI wording was corrected after a brittle text-match failure
+- purpose: keep governance checks usable against real repo wording
+
+### 2026-04-13 / main / PR #36 merged
+- initial component current-state and stream journals were added for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+- purpose: move active component handoff memory into repo-native journals
+
+### 2026-04-13 / main / PR #37 merged
+- missing tuner current-state journal gap was closed
+- purpose: restore journal completeness for active components
+
+### 2026-04-13 / main / PR #38 merged
+- stub component READMEs were replaced with short governed component overviews
+- purpose: improve human and agent pickup quality at component roots
+
+### 2026-04-13 / main / PR #39 merged
+- CI checks for active component journals and READMEs were added
+- purpose: turn journal discipline into repo-enforced hygiene
+
+### 2026-04-14 / main / PR #40 merged
+- process docs for technology changes, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence were added
+- purpose: normalize liveable interdependency handling and active review discipline
+
+### 2026-04-14 / main / PR #41 merged
+- SI recovery onboarding and continuity docs were added
+- purpose: reduce chat-loss risk and keep SI/N operating memory inside Git
+
+### 2026-04-14 / main / PR #42 merged
+- corrected new-component intake governance and SI doctrine updates were added
+- purpose: make new component bootstrap repeatable and repo-native
+
+### 2026-04-14 / main / PR #43 merged
+- remaining intake follow-up docs and AGENTS replacement notes were added
+- purpose: close gaps left behind by the earlier intake merge sequence
+
+### 2026-04-14 / main / PR #44 merged
+- AGENTS references were updated
+- purpose: reduce stale onboarding pointers
+
+### 2026-04-14 / main / PR #46 merged
+- old AGENTS bootstrap wording was removed
+- purpose: avoid pointing future chats at outdated intake behavior
+
+### 2026-04-14 / main / PR #48 merged
+- one-click rebase workflow for `dev/*` and `integration/*` branches was added
+- purpose: reduce manual branch alignment work
+
+### 2026-04-14 / main / PR #50 merged
+- weekly governance report issue workflow was added
+- purpose: create a repo-native recurring oversight loop
+
+### 2026-04-14 / main / PR #52 merged
+- issue governance routing and automation workflows were added
+- purpose: turn repo truth into a managed operating queue
+
+### 2026-04-14 / main / PR #53 merged
+- governance closeout workflow was added
+- purpose: close the issue loop after merges
+
+### 2026-04-14 / main / PR #55 merged
+- autonomy layer, escalation workflows, and repo sanity controls were added
+- purpose: move toward lower-admin autonomous execution from repo truth
+
+### 2026-04-14 / main / PR #57 and PR #58 merged
+- intake and PR routing behavior was corrected
+- purpose: keep label-driven automation responsive to real events
+
+### 2026-04-14 / main / PR #60 merged
+- corrected issue-intake normalizer v2 was added
+- purpose: unblock the first live governance-loop validation
+
+### 2026-04-14 / main / PR #61 merged
+- first live governance-loop validation was recorded
+- purpose: confirm the governed demand path is active in repo truth
+
+### 2026-04-14 / si-alignment-v1 / current branch
+- SI governance index v5 was added
+- protected-main truth maintenance operating model was added
+- SI recovery onboarding v5 was added
+- SI status v6 and decisions v6 were added
+- stream v2 and `ag_new.txt` were created to align protected-main SI truth under connector mutation limits
+- purpose: align SI repo truth to the locked public/protected-main operating model
+
+### 2026-04-14 / si-alignment-v1 / current branch / deploy exclusivity follow-up
+- deploy target exclusivity standard was added
+- lock-aware deploy, rollback, explicit release, and autonomous orchestrator workflow generations were added
+- the Pi target state model `free`, `deploying`, `test_open`, `rollback_running`, and `blocked` was locked as repo truth
+- SI status v7 and decisions v7 were added
+- purpose: prevent overlapping deploy/test windows on the same target Pi and preserve valid runtime acceptance evidence
+
+### 2026-04-14 / si-alignment-v1 / current branch / truthful execution follow-up
+- truthful execution and negative-answer governance standard was added
+- SI decisions v8 was added with the locked rule that an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery
+- purpose: keep repo truth and owner communication trustworthy even under tool, connector, or runtime limitations

--- a/journals/system-integration-normalization/stream_v5.md
+++ b/journals/system-integration-normalization/stream_v5.md
@@ -1,0 +1,122 @@
+# STREAM — system_integration_normalization
+
+Status note: this v5 file supersedes `stream_v4.md` as the current SI/N stream because the governed Git release-tagging rule materially changed the release-management model after the truthfulness alignment.
+
+## Entries
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 / main / PR #31 merged
+- branch doctrine, component artifact model, and naming/release numbering standards were added
+- purpose: stop recurring branch and multi-artifact ambiguity
+
+### 2026-04-13 / main / PR #32 merged
+- repo-level agent onboarding files and skills were added
+- purpose: reduce repeated context rebuilding for future agent work
+
+### 2026-04-13 / main / PR #33 merged
+- canonical governance source precedence and overlay contract docs were added
+- purpose: reduce doctrine conflicts and give overlay behavior a formal governance home
+
+### 2026-04-13 / main / PR #35 merged
+- governance CI wording was corrected after a brittle text-match failure
+- purpose: keep governance checks usable against real repo wording
+
+### 2026-04-13 / main / PR #36 merged
+- initial component current-state and stream journals were added for Bridge, Tuner, Starter, AutoSwitch, Fun Line, and Hardware
+- purpose: move active component handoff memory into repo-native journals
+
+### 2026-04-13 / main / PR #37 merged
+- missing tuner current-state journal gap was closed
+- purpose: restore journal completeness for active components
+
+### 2026-04-13 / main / PR #38 merged
+- stub component READMEs were replaced with short governed component overviews
+- purpose: improve human and agent pickup quality at component roots
+
+### 2026-04-13 / main / PR #39 merged
+- CI checks for active component journals and READMEs were added
+- purpose: turn journal discipline into repo-enforced hygiene
+
+### 2026-04-14 / main / PR #40 merged
+- process docs for technology changes, component interdependency mapping, repo-truth cleanup backlog, and status/decision review cadence were added
+- purpose: normalize liveable interdependency handling and active review discipline
+
+### 2026-04-14 / main / PR #41 merged
+- SI recovery onboarding and continuity docs were added
+- purpose: reduce chat-loss risk and keep SI/N operating memory inside Git
+
+### 2026-04-14 / main / PR #42 merged
+- corrected new-component intake governance and SI doctrine updates were added
+- purpose: make new component bootstrap repeatable and repo-native
+
+### 2026-04-14 / main / PR #43 merged
+- remaining intake follow-up docs and AGENTS replacement notes were added
+- purpose: close gaps left behind by the earlier intake merge sequence
+
+### 2026-04-14 / main / PR #44 merged
+- AGENTS references were updated
+- purpose: reduce stale onboarding pointers
+
+### 2026-04-14 / main / PR #46 merged
+- old AGENTS bootstrap wording was removed
+- purpose: avoid pointing future chats at outdated intake behavior
+
+### 2026-04-14 / main / PR #48 merged
+- one-click rebase workflow for `dev/*` and `integration/*` branches was added
+- purpose: reduce manual branch alignment work
+
+### 2026-04-14 / main / PR #50 merged
+- weekly governance report issue workflow was added
+- purpose: create a repo-native recurring oversight loop
+
+### 2026-04-14 / main / PR #52 merged
+- issue governance routing and automation workflows were added
+- purpose: turn repo truth into a managed operating queue
+
+### 2026-04-14 / main / PR #53 merged
+- governance closeout workflow was added
+- purpose: close the issue loop after merges
+
+### 2026-04-14 / main / PR #55 merged
+- autonomy layer, escalation workflows, and repo sanity controls were added
+- purpose: move toward lower-admin autonomous execution from repo truth
+
+### 2026-04-14 / main / PR #57 and PR #58 merged
+- intake and PR routing behavior was corrected
+- purpose: keep label-driven automation responsive to real events
+
+### 2026-04-14 / main / PR #60 merged
+- corrected issue-intake normalizer v2 was added
+- purpose: unblock the first live governance-loop validation
+
+### 2026-04-14 / main / PR #61 merged
+- first live governance-loop validation was recorded
+- purpose: confirm the governed demand path is active in repo truth
+
+### 2026-04-14 / si-alignment-v1 / current branch
+- SI governance index v5 was added
+- protected-main truth maintenance operating model was added
+- SI recovery onboarding v5 was added
+- SI status v6 and decisions v6 were added
+- stream v2 and `ag_new.txt` were created to align protected-main SI truth under connector mutation limits
+- purpose: align SI repo truth to the locked public/protected-main operating model
+
+### 2026-04-14 / si-alignment-v1 / current branch / deploy exclusivity follow-up
+- deploy target exclusivity standard was added
+- lock-aware deploy, rollback, explicit release, and autonomous orchestrator workflow generations were added
+- the Pi target state model `free`, `deploying`, `test_open`, `rollback_running`, and `blocked` was locked as repo truth
+- SI status v7 and decisions v7 were added
+- purpose: prevent overlapping deploy/test windows on the same target Pi and preserve valid runtime acceptance evidence
+
+### 2026-04-14 / si-alignment-v1 / current branch / truthful execution follow-up
+- truthful execution and negative-answer governance standard was added
+- SI decisions v8 was added with the locked rule that an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery
+- purpose: keep repo truth and owner communication trustworthy even under tool, connector, or runtime limitations
+
+### 2026-04-14 / si-alignment-v1 / current branch / release-tagging follow-up
+- Git release tagging standard was added
+- SI decisions v9 was added with the locked rule that Git tags are created only for accepted stable baselines and governed rollback anchors using the format `<component-suffix>-vMAJOR.MINOR.PATCH`
+- purpose: keep Git tags meaningful and conservative instead of polluting history with intermediate states

--- a/tools/deploy/pi-test-slot-v1.sh
+++ b/tools/deploy/pi-test-slot-v1.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+TARGET="${2:-primary}"
+COMPONENT="${3:-}"
+GIT_REF="${4:-}"
+PAYLOAD="${5:-}"
+OWNER="${6:-}"
+ARG7="${7:-}"
+ARG8="${8:-}"
+
+STATE_DIR="${PI_TEST_SLOT_STATE_DIR:-/opt/scale-radio/state}"
+STATE_FILE="$STATE_DIR/pi_test_slot_${TARGET}.json"
+LOCK_DIR="$STATE_FILE.lockdir"
+mkdir -p "$STATE_DIR"
+
+python3 - "$ACTION" "$TARGET" "$COMPONENT" "$GIT_REF" "$PAYLOAD" "$OWNER" "$ARG7" "$ARG8" "$STATE_FILE" "$LOCK_DIR" <<'PY'
+import json
+import os
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ACTION, TARGET, COMPONENT, GIT_REF, PAYLOAD, OWNER, ARG7, ARG8, STATE_FILE, LOCK_DIR = sys.argv[1:11]
+state_path = Path(STATE_FILE)
+lock_path = Path(LOCK_DIR)
+now = int(time.time())
+
+
+def iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def load_state():
+    if not state_path.exists():
+        return None
+    return json.loads(state_path.read_text(encoding='utf-8'))
+
+
+def save_state(state):
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def release_lockdir():
+    if lock_path.exists():
+        shutil.rmtree(lock_path)
+
+
+def exit_with(code: int, message: str):
+    print(message)
+    raise SystemExit(code)
+
+
+try:
+    lock_path.mkdir()
+except FileExistsError:
+    exit_with(91, f'target-slot-lock-busy target={TARGET}')
+
+try:
+    state = load_state()
+    state_name = (state or {}).get('state', 'free')
+    lease_expires_at = (state or {}).get('lease_expires_at_epoch')
+    expired = bool(lease_expires_at and lease_expires_at < now)
+
+    if ACTION == 'status':
+        if not state:
+            print(json.dumps({'target': TARGET, 'state': 'free'}, indent=2))
+            raise SystemExit(0)
+        print(json.dumps(state, indent=2, sort_keys=True))
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-deploy':
+        hold_minutes = int(ARG7 or '240')
+        if state and state_name in ('deploying', 'test_open', 'rollback_running', 'blocked') and not expired:
+            exit_with(10, f'target-not-free target={TARGET} state={state_name}')
+        lease_until = now + hold_minutes * 60
+        save_state({
+            'target': TARGET,
+            'state': 'deploying',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': now,
+            'acquired_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'acquired-deploy-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-test-open':
+        hold_minutes = int(ARG7 or '240')
+        lease_until = now + hold_minutes * 60
+        if not state:
+            exit_with(12, f'no-active-slot target={TARGET}')
+        save_state({
+            'target': TARGET,
+            'state': 'test_open',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'test_opened_at_epoch': now,
+            'test_opened_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'marked-test-open target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-rollback':
+        if not state:
+            exit_with(13, f'no-slot-to-rollback target={TARGET}')
+        if state_name not in ('test_open', 'blocked') and not expired:
+            exit_with(14, f'rollback-not-allowed target={TARGET} state={state_name}')
+        if state.get('component') and state.get('component') != COMPONENT:
+            exit_with(15, f'rollback-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+        lease_until = now + 60 * 60
+        save_state({
+            'target': TARGET,
+            'state': 'rollback_running',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'rollback_started_at_epoch': now,
+            'rollback_started_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'acquired-rollback-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-blocked':
+        reason = ARG7 or 'unspecified'
+        save_state({
+            'target': TARGET,
+            'state': 'blocked',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'blocked_at_epoch': now,
+            'blocked_at': iso(now),
+            'reason': reason,
+        })
+        print(f'marked-blocked target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    if ACTION == 'release':
+        reason = ARG7 or 'released'
+        force = (ARG8 or '').lower() in ('1', 'true', 'yes', 'force')
+        if not state:
+            print(f'already-free target={TARGET}')
+            raise SystemExit(0)
+        if not force:
+            if state.get('component') and COMPONENT and state.get('component') != COMPONENT:
+                exit_with(16, f'release-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+            if state.get('git_ref') and GIT_REF and state.get('git_ref') != GIT_REF:
+                exit_with(17, f'release-git-ref-mismatch target={TARGET} state_git_ref={state.get("git_ref")} requested_git_ref={GIT_REF}')
+        state_path.unlink(missing_ok=True)
+        print(f'released-slot target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    exit_with(2, f'unsupported-action action={ACTION}')
+finally:
+    release_lockdir()
+PY

--- a/tools/governance/autonomous_delivery_matrix_v2.json
+++ b/tools/governance/autonomous_delivery_matrix_v2.json
@@ -1,0 +1,35 @@
+{
+  "components": {
+    "bridge": {
+      "auto_delivery_supported": true,
+      "default_git_ref": "dev/bridge",
+      "default_payload": "current_dev",
+      "deploy_workflow": "component-test-deploy-v7.yml",
+      "rollback_workflow": "component-test-rollback-v7.yml"
+    },
+    "tuner": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "starter": {
+      "auto_delivery_supported": false,
+      "reason": "starter repo truth and deploy contract remain unresolved"
+    },
+    "autoswitch": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "fun-line": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "hardware": {
+      "auto_delivery_supported": false,
+      "reason": "non-deploy payload lane"
+    },
+    "system-integration": {
+      "auto_delivery_supported": false,
+      "reason": "control-plane lane"
+    }
+  }
+}


### PR DESCRIPTION
Adds the pending system-integration alignment package based on the now-locked operating model.

Included:
- `contracts/repo/system_integration_governance_index_v5.md`
- `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
- `docs/agents/system_integration_recovery_onboarding_v5.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v6.md`
- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v6.md`
- `journals/system-integration-normalization/stream_v2.md`
- `ag_new.txt`

What this does:
- aligns SI repo truth to the locked public + protected-`main` operating model
- records the default SI branch model: short-lived repo-control-plane branches to `main`
- records the rule that technical execution blockers must escalate and inform instead of improvising or faking completion
- adds the standard protected-main replacement-file operating model for cases where the connector cannot safely mutate an existing truth file
- refreshes SI recovery onboarding and status/decision truth
- creates a new SI stream file because the existing `stream_v1.md` had become stale and was awkward to mutate safely through the current connector surface

Important owner action:
- `ag_new.txt` is the intended replacement content for top-level `AGENTS.md`
- this is using the newly documented replacement-file exception path because the current connector surface is clean for branch/new-file/PR work but still awkward for safe in-place mutation of that protected truth file
- after review, please apply `ag_new.txt` to `AGENTS.md` on `main`

Why this matters:
- keeps SI truth aligned without pretending a direct protected-truth mutation worked when it did not
- preserves low-click review while keeping journals, decisions, and streams as mandatory repo truth
- makes the connector/tool limitation itself part of governed repo doctrine instead of a recurring surprise
