### PR TITLE
Add SI handover and owner click guide docs

### DIFF
--- a/docs/agents/system_integration_recovery_onboarding_v5.md
+++ b/docs/agents/system_integration_recovery_onboarding_v5.md
@@ -1,0 +1,111 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V5
+
+## Purpose
+This file is the fast re-entry and handover guide for a replacement system integration / normalization chat.
+
+## Current operating model
+The repository is no longer only governance-doc driven.
+It is now an issue-driven, workflow-backed control plane.
+Use repo-native issues, labels, workflows, journals, and contracts as the operating system.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- issue routing and escalation discipline
+- autonomous execution guardrails
+- cross-component normalization
+- repo-truth cleanup where uncertainty still exists
+
+Do not assume deep specialist implementation ownership inside a component unless the repo state clearly requires it.
+
+## Current repo truth snapshot
+- repository: `SH99999/mediastreamer`
+- truth branch: `main`
+- active component branches:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- current governance layer includes:
+  - one-click branch rebase workflow
+  - weekly governance report issue workflow
+  - issue-governance routing automation
+  - governance closeout workflow
+  - autonomy/intake/escalation layer
+  - corrected issue-intake normalizer v2
+  - first live governance-loop validation already recorded
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v4.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_artifact_model_v1.md`
+5. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+6. `contracts/repo/release_intake_and_delivery_status_v2.md`
+7. `contracts/repo/component_journal_policy_v2.md`
+8. `contracts/repo/new_component_intake_standard_v2.md`
+9. `contracts/repo/issue_governance_routing_standard_v1.md`
+10. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+11. `contracts/repo/system_integration_escalation_contract_v1.md`
+12. `journals/system-integration-normalization/STATUS_system_integration_normalization_v5.md`
+13. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v5.md`
+14. `journals/system-integration-normalization/stream_v1.md`
+15. active component journals under `journals/<component>/`
+
+## Key workflows to know immediately
+### Branch and repo health
+- `rebase-dev-and-integration-branches-on-main.yml`
+- `weekly-governance-report-issue.yml`
+- `release-readiness-audit.yml`
+- `repo-health-v3.yml`
+- `governance-health-v2.yml`
+- `component-health-v1.yml`
+
+### Issue governance and queue generation
+- `ensure-governance-labels.yml`
+- `open-decision-issues.yml`
+- `branch-drift-issues.yml`
+- `journal-freshness-issues.yml`
+- `stale-governance-items.yml`
+- `pr-governance-review.yml`
+- `governance-closeout.yml`
+
+### Intake and autonomy
+- `issue-intake-normalizer-v2.yml`
+- `issue-context-enrichment.yml`
+- `system-integration-escalation.yml`
+- `autonomous-delivery-orchestrator.yml`
+- `decision-verification-on-merge.yml`
+- `repo-control-plane-sanity-check.yml`
+- `bootstrap-new-component.yml`
+
+### Component deploy/test workflows still relevant
+- `component-test-deploy-v6.yml`
+- `component-test-rollback-v6.yml`
+
+## Working rule
+- use the issue-routing model instead of ad-hoc chat-side task memory
+- if work is cross-component or system-wide, escalate automatically to SI/governance
+- if a component is not support-matrix delivery-capable, do not pretend autonomous delivery support exists
+- keep repo-truth cleanup visible in docs/journals/issues instead of hiding uncertainty
+
+## Current practical priorities
+1. keep the governance/issue-control-plane working
+2. keep active branches aligned to `main`
+3. resolve repo-truth uncertainty where still open, highest priority:
+   - starter
+   - fun-line
+   - hardware
+4. keep component journals and decisions updated as active repo truth
+
+## Minimum completion condition for a replacement SI chat
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what the current issue-routing model is
+- how escalation is triggered
+- which workflows are operator-facing versus background automation
+- which components are currently delivery-capable
+- which uncertainties are explicitly tracked in repo truth instead of assumed away

--- a/docs/operators/owner_click_guide_v1.md
+++ b/docs/operators/owner_click_guide_v1.md
@@ -1,0 +1,151 @@
+# OWNER CLICK GUIDE V1
+
+## Purpose
+This file explains what the repository already automates, what the owner should click or decide, and how to interpret governance issues and workflows.
+
+## Your role
+Your role is mainly:
+- approve or reject real decisions
+- merge reviewed PRs into protected `main`
+- run a few key manual workflows when needed
+- use the issue queue as a management dashboard, not as a second source of truth
+
+You should not need to do repetitive routing, label maintenance, branch-list maintenance, or repetitive cleanup if the repo can do it automatically.
+
+## Core rule for issues
+Issues are the **operating queue** built from repo truth.
+Contracts and journals remain the actual truth source.
+
+## What to do with created issues
+### Informational only
+Usually informational / monitoring issues:
+- weekly governance report issues
+- branch drift issues where you only need visibility before choosing to rebase
+- journal freshness issues if the responsible lane can handle them without your decision
+
+### Act / decide
+You should act when an issue has labels or meaning such as:
+- `state:needs-decision`
+- `state:awaiting-owner`
+- `impact:system-wide`
+- `impact:cross-component`
+- `type:decision`
+- or the issue clearly asks for approval of one path over another
+
+### After decision
+Your decision should normally result in:
+1. a PR updating docs/journals/workflows if needed
+2. merge to `main`
+3. governance closeout workflow handling the issue state automatically
+
+## Most important workflows for you
+### 1. `rebase-dev-and-integration-branches-on-main`
+Use when:
+- active branches have drifted behind `main`
+- before starting a new dev block
+What it does:
+- rebases all `dev/*` and `integration/*` branches, or one selected branch, onto `main`
+- pushes rebased branches back automatically
+Your click pattern:
+- Actions -> `rebase-dev-and-integration-branches-on-main` -> Run workflow
+- choose `all` or `single`
+
+### 2. `component-test-deploy-v6`
+Use when:
+- you want to test deploy a component payload to the Pi
+What it does:
+- checks out `main` control-plane state
+- checks out the selected `git_ref` into a target dir
+- deploys via repo wrapper against the selected payload
+Your click pattern:
+- Actions -> `component-test-deploy-v6` -> Run workflow
+- choose `git_ref`, `component`, `payload`
+
+### 3. `component-test-rollback-v6`
+Use when:
+- you want to remove/rollback a deployed test payload from the Pi
+What it does:
+- checks out `main` control-plane state
+- checks out the selected `git_ref`
+- runs repo rollback via wrapper
+
+### 4. `release-readiness-audit`
+Use when:
+- you want a compressed readiness view before broader development or release decisions
+What it does:
+- checks README/current_state/stream presence
+- checks branch drift
+- checks open decisions
+- writes a summary table
+
+### 5. `weekly-governance-report-issue`
+Use when:
+- you want a current weekly management summary immediately rather than waiting for schedule
+What it does:
+- creates or updates one weekly governance report issue from repo truth
+
+### 6. `issue-intake-normalizer-v2`
+Use when:
+- a new governed issue was created but labels/routing look wrong
+- an intake issue needs manual normalization
+What it does:
+- reads the issue body and applies the managed labels correctly
+
+### 7. `bootstrap-new-component`
+Use when:
+- a truly new governed component must be created under the repo model
+What it does:
+- creates the governed bootstrap structure for the new component
+
+## Important background automation you usually do not need to run manually
+- `ensure-governance-labels`
+- `open-decision-issues`
+- `branch-drift-issues`
+- `journal-freshness-issues`
+- `pr-governance-review`
+- `governance-closeout`
+- `issue-context-enrichment`
+- `system-integration-escalation`
+- `decision-verification-on-merge`
+- `repo-control-plane-sanity-check`
+- `autonomous-delivery-orchestrator`
+
+These mostly keep the queue, routing, escalation, and closure loops alive in the background.
+
+## Communication model
+### Best way to communicate work
+- discuss demand in chat
+- create or update a governed issue if the work needs repo visibility/routing
+- let labels/workflows route it
+- ask the relevant specialist lane or SI lane to prepare the PR
+- merge when ready
+
+### When to escalate in chat immediately
+Bring work to system integration first when it affects:
+- multiple components
+- workflows
+- rollback/deploy rules
+- governance docs
+- naming/branch doctrine
+- shared UX standards or shared asset rules
+
+## Practical owner loop
+1. review the issue queue and weekly report
+2. decide only the items that truly need owner choice
+3. let chats/agents prepare PRs
+4. review/merge PRs to `main`
+5. run deploy/rebase/audit workflows when needed
+
+## What you usually do NOT need to do
+- manually classify issues one by one if the intake model worked
+- manually maintain label taxonomy
+- manually keep a spreadsheet or parallel project memory
+- manually rebase branches from your PC unless the workflow path is broken
+
+## Current caution
+The system is now strong enough to operate, but repo-truth cleanup is still important for:
+- starter
+- fun-line
+- hardware
+
+Those areas may still need more direct SI attention than the more automated/governed parts of the system.


### PR DESCRIPTION
Adds two repo-native docs to make the current system integration / governance control plane easier to hand over and easier for the owner to operate.

Included:
- `docs/agents/system_integration_recovery_onboarding_v5.md`
- `docs/operators/owner_click_guide_v1.md`

What this does:
- updates the SI recovery/handover doc to the newer issue-driven, workflow-backed governance model
- explains the current operating model for a replacement SI chat
- gives the owner a practical guide for what issues mean, when action is needed, and which workflows matter most
- separates operator-facing workflows from background automation

Why this matters now:
- the repo has moved beyond the older manual governance layer into PRs/workflows in the 50s/60s
- another chat should be able to take over SI/N without reconstructing the newer model from chat memory
- the owner needs one place that answers “what do I click, when, and why?”
