### PR TITLE
Fix Bridge deploy pointer resolution and failure rollback recovery

### DIFF
--- a/.github/workflows/autonomous-delivery-orchestrator-v3.yml
+++ b/.github/workflows/autonomous-delivery-orchestrator-v3.yml
@@ -1,0 +1,130 @@
+name: autonomous-delivery-orchestrator-v3
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to deploy through the autonomous orchestrator"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component suffix, for example bridge"
+        required: true
+        default: "bridge"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+  pull-requests: read
+
+jobs:
+  orchestrate_delivery:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Dispatch supported autonomous delivery
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_GIT_REF: ${{ inputs.git_ref }}
+          INPUT_COMPONENT: ${{ inputs.component }}
+          INPUT_TARGET: ${{ inputs.target }}
+          INPUT_TEST_HOLD_MINUTES: ${{ inputs.test_hold_minutes }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re, urllib.request
+          from pathlib import Path
+
+          repo = os.environ['GITHUB_REPOSITORY']
+          token = os.environ['GITHUB_TOKEN']
+          event_name = os.environ['EVENT_NAME']
+          pr_number = os.environ.get('PR_NUMBER') or ''
+          pr_head_ref = os.environ.get('PR_HEAD_REF') or ''
+          input_git_ref = os.environ.get('INPUT_GIT_REF') or ''
+          input_component = os.environ.get('INPUT_COMPONENT') or ''
+          input_target = os.environ.get('INPUT_TARGET') or 'primary'
+          input_test_hold_minutes = os.environ.get('INPUT_TEST_HOLD_MINUTES') or '240'
+          matrix = json.loads(Path('tools/governance/autonomous_delivery_matrix_v3.json').read_text(encoding='utf-8'))['components']
+          base = f'https://api.github.com/repos/{repo}'
+          headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'autonomous-delivery-orchestrator-v3'
+          }
+
+          def req(method, path, data=None):
+            body = None if data is None else json.dumps(data).encode('utf-8')
+            h = dict(headers)
+            if body is not None:
+              h['Content-Type'] = 'application/json'
+            r = urllib.request.Request(base + path, data=body, headers=h, method=method)
+            with urllib.request.urlopen(r) as resp:
+              raw = resp.read().decode('utf-8')
+              return json.loads(raw) if raw else None
+
+          def route_from_event():
+            if event_name == 'workflow_dispatch':
+              return input_component.strip(), input_git_ref.strip(), 'manual-dispatch'
+            m = re.fullmatch(r'dev/([a-z0-9-]+)', pr_head_ref.strip())
+            if m:
+              return m.group(1), pr_head_ref.strip(), 'merged-dev-branch'
+            return None, None, 'non-dev-pr-head'
+
+          component, git_ref, reason = route_from_event()
+          if not component or not git_ref:
+            print(f'skipped: {reason}')
+            raise SystemExit(0)
+
+          spec = matrix.get(component)
+          if not spec or not spec.get('auto_delivery_supported'):
+            title = f'Autonomous delivery skipped — {component}'
+            body = '\n'.join([
+              '# Autonomous delivery skipped',
+              '',
+              f'- component: `{component}`',
+              f'- git ref: `{git_ref}`',
+              f'- reason: `{spec.get("reason", "not in delivery matrix") if spec else "not in delivery matrix"}`',
+              '',
+              '## Required next step',
+              '- normalize deploy and rollback contracts before enabling autonomous delivery for this component',
+            ])
+            req('POST', '/issues', {'title': title, 'body': body, 'labels': ['governance','component:system-integration','agent:system-integration','type:integration-risk','impact:system-wide','state:ready-for-agent','source:manual']})
+            raise SystemExit(0)
+
+          payload = spec.get('default_payload', 'current_dev')
+          workflow = spec['deploy_workflow']
+          req('POST', f'/actions/workflows/{workflow}/dispatches', {'ref': 'main', 'inputs': {'git_ref': git_ref, 'component': component, 'payload': payload, 'target': input_target, 'test_hold_minutes': input_test_hold_minutes}})
+
+          if pr_number:
+            req('POST', f'/issues/{pr_number}/comments', {'body': '\n'.join([
+              '<!-- autonomous-delivery-orchestrator-v3 -->',
+              'Autonomous delivery dispatched.',
+              '',
+              f'- component: `{component}`',
+              f'- git ref: `{git_ref}`',
+              f'- payload: `{payload}`',
+              f'- target: `{input_target}`',
+              f'- source: `{reason}`',
+              '- target exclusivity is enforced by the deploy workflow on the Pi slot before runtime mutation.',
+              '- bridge payload pointers are resolved by the v2 wrapper so current_dev can map cleanly to the current governed Bridge candidate when the branch payload tree does not expose a literal current_dev directory.',
+            ])})
+          else:
+            print(f'dispatched component={component} git_ref={git_ref} payload={payload} target={input_target}')
+          PY

--- a/.github/workflows/component-test-deploy-v8.yml
+++ b/.github/workflows/component-test-deploy-v8.yml
@@ -1,0 +1,95 @@
+name: component-test-deploy-v8
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow/control-plane repository state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Acquire target deploy slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh acquire-deploy "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Apply selected payload via repo wrapper
+        id: apply_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v2.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Mark target slot as test_open
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh mark-test-open "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Roll back selected payload on failure
+        id: rollback_on_failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}"
+          bash tools/deploy/sr-deploy-wrapper-v2.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful failure rollback
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome == 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}" "deploy_failed_rollback_completed"
+
+      - name: Mark target slot blocked when deploy/rollback did not complete cleanly
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome != 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "deploy_or_failure_rollback_incomplete"

--- a/.github/workflows/component-test-deploy-v9.yml
+++ b/.github/workflows/component-test-deploy-v9.yml
@@ -1,0 +1,95 @@
+name: component-test-deploy-v9
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow/control-plane repository state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Acquire target deploy slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-deploy "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Apply selected payload via repo wrapper
+        id: apply_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v2.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Mark target slot as test_open
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-test-open "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Roll back selected payload on failure
+        id: rollback_on_failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}"
+          bash tools/deploy/sr-deploy-wrapper-v2.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful failure rollback
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome == 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}" "deploy_failed_rollback_completed"
+
+      - name: Mark target slot blocked when deploy/rollback did not complete cleanly
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome != 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "deploy_or_failure_rollback_incomplete"

--- a/.github/workflows/component-test-release-slot-v2.yml
+++ b/.github/workflows/component-test-release-slot-v2.yml
@@ -1,0 +1,53 @@
+name: component-test-release-slot-v2
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      component:
+        description: "Component that currently owns the test slot"
+        required: true
+        default: "bridge"
+      git_ref:
+        description: "Git ref that currently owns the test slot"
+        required: true
+        default: "dev/bridge"
+      payload:
+        description: "Payload currently associated with the test slot"
+        required: true
+        default: "current_dev"
+      reason:
+        description: "Why the slot is being released"
+        required: true
+        default: "accepted_candidate"
+      force:
+        description: "Force release even if the recorded state does not match"
+        required: true
+        default: "false"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  release_target_slot:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          test -w /opt/scale-radio/state
+
+      - name: Release target test slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "release:${GITHUB_RUN_ID}" "${{ inputs.reason }}" "${{ inputs.force }}"

--- a/.github/workflows/component-test-release-slot-v3.yml
+++ b/.github/workflows/component-test-release-slot-v3.yml
@@ -1,0 +1,53 @@
+name: component-test-release-slot-v3
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      component:
+        description: "Component that currently owns the test slot"
+        required: true
+        default: "bridge"
+      git_ref:
+        description: "Git ref that currently owns the test slot"
+        required: true
+        default: "dev/bridge"
+      payload:
+        description: "Payload currently associated with the test slot"
+        required: true
+        default: "current_dev"
+      reason:
+        description: "Why the slot is being released"
+        required: true
+        default: "accepted_candidate"
+      force:
+        description: "Force release even if the recorded state does not match"
+        required: true
+        default: "false"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  release_target_slot:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          test -w /opt/scale-radio/state
+
+      - name: Release target test slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "release:${GITHUB_RUN_ID}" "${{ inputs.reason }}" "${{ inputs.force }}"

--- a/.github/workflows/component-test-rollback-v8.yml
+++ b/.github/workflows/component-test-rollback-v8.yml
@@ -1,0 +1,73 @@
+name: component-test-rollback-v8
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+
+      - name: Acquire target rollback slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}"
+
+      - name: Roll back selected payload via repo wrapper
+        id: rollback_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v2.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful rollback
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_completed"
+
+      - name: Mark target slot blocked on rollback failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v2.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_incomplete"

--- a/.github/workflows/component-test-rollback-v9.yml
+++ b/.github/workflows/component-test-rollback-v9.yml
@@ -1,0 +1,73 @@
+name: component-test-rollback-v9
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+
+      - name: Acquire target rollback slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}"
+
+      - name: Roll back selected payload via repo wrapper
+        id: rollback_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v2.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful rollback
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_completed"
+
+      - name: Mark target slot blocked on rollback failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_incomplete"

--- a/tools/deploy/pi-test-slot-v2.sh
+++ b/tools/deploy/pi-test-slot-v2.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+TARGET="${2:-primary}"
+COMPONENT="${3:-}"
+GIT_REF="${4:-}"
+PAYLOAD="${5:-}"
+OWNER="${6:-}"
+ARG7="${7:-}"
+ARG8="${8:-}"
+
+STATE_DIR="${PI_TEST_SLOT_STATE_DIR:-/opt/scale-radio/state}"
+STATE_FILE="$STATE_DIR/pi_test_slot_${TARGET}.json"
+LOCK_DIR="$STATE_FILE.lockdir"
+mkdir -p "$STATE_DIR"
+
+python3 - "$ACTION" "$TARGET" "$COMPONENT" "$GIT_REF" "$PAYLOAD" "$OWNER" "$ARG7" "$ARG8" "$STATE_FILE" "$LOCK_DIR" <<'PY'
+import json
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ACTION, TARGET, COMPONENT, GIT_REF, PAYLOAD, OWNER, ARG7, ARG8, STATE_FILE, LOCK_DIR = sys.argv[1:11]
+state_path = Path(STATE_FILE)
+lock_path = Path(LOCK_DIR)
+now = int(time.time())
+
+
+def iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def load_state():
+    if not state_path.exists():
+        return None
+    return json.loads(state_path.read_text(encoding='utf-8'))
+
+
+def save_state(state):
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def release_lockdir():
+    if lock_path.exists():
+        shutil.rmtree(lock_path)
+
+
+def exit_with(code: int, message: str):
+    print(message)
+    raise SystemExit(code)
+
+
+try:
+    lock_path.mkdir()
+except FileExistsError:
+    exit_with(91, f'target-slot-lock-busy target={TARGET}')
+
+try:
+    state = load_state()
+    state_name = (state or {}).get('state', 'free')
+    lease_expires_at = (state or {}).get('lease_expires_at_epoch')
+    expired = bool(lease_expires_at and lease_expires_at < now)
+
+    if ACTION == 'status':
+        if not state:
+            print(json.dumps({'target': TARGET, 'state': 'free'}, indent=2))
+            raise SystemExit(0)
+        print(json.dumps(state, indent=2, sort_keys=True))
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-deploy':
+        hold_minutes = int(ARG7 or '240')
+        if state and state_name in ('deploying', 'test_open', 'rollback_running', 'blocked') and not expired:
+            exit_with(10, f'target-not-free target={TARGET} state={state_name}')
+        lease_until = now + hold_minutes * 60
+        save_state({
+            'target': TARGET,
+            'state': 'deploying',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': now,
+            'acquired_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'acquired-deploy-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-test-open':
+        hold_minutes = int(ARG7 or '240')
+        lease_until = now + hold_minutes * 60
+        if not state:
+            exit_with(12, f'no-active-slot target={TARGET}')
+        save_state({
+            'target': TARGET,
+            'state': 'test_open',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'test_opened_at_epoch': now,
+            'test_opened_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'marked-test-open target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-rollback':
+        if not state:
+            exit_with(13, f'no-slot-to-rollback target={TARGET}')
+        if state_name not in ('deploying', 'test_open', 'blocked') and not expired:
+            exit_with(14, f'rollback-not-allowed target={TARGET} state={state_name}')
+        if state.get('component') and state.get('component') != COMPONENT:
+            exit_with(15, f'rollback-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+        if state.get('git_ref') and state.get('git_ref') != GIT_REF and not expired:
+            exit_with(18, f'rollback-git-ref-mismatch target={TARGET} state_git_ref={state.get("git_ref")} requested_git_ref={GIT_REF}')
+        lease_until = now + 60 * 60
+        save_state({
+            'target': TARGET,
+            'state': 'rollback_running',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'rollback_started_at_epoch': now,
+            'rollback_started_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+            'previous_state': state_name,
+        })
+        print(f'acquired-rollback-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-blocked':
+        reason = ARG7 or 'unspecified'
+        save_state({
+            'target': TARGET,
+            'state': 'blocked',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'blocked_at_epoch': now,
+            'blocked_at': iso(now),
+            'reason': reason,
+        })
+        print(f'marked-blocked target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    if ACTION == 'release':
+        reason = ARG7 or 'released'
+        force = (ARG8 or '').lower() in ('1', 'true', 'yes', 'force')
+        if not state:
+            print(f'already-free target={TARGET}')
+            raise SystemExit(0)
+        if not force:
+            if state.get('component') and COMPONENT and state.get('component') != COMPONENT:
+                exit_with(16, f'release-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+            if state.get('git_ref') and GIT_REF and state.get('git_ref') != GIT_REF:
+                exit_with(17, f'release-git-ref-mismatch target={TARGET} state_git_ref={state.get("git_ref")} requested_git_ref={GIT_REF}')
+        state_path.unlink(missing_ok=True)
+        print(f'released-slot target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    exit_with(2, f'unsupported-action action={ACTION}')
+finally:
+    release_lockdir()
+PY

--- a/tools/deploy/pi-test-slot-v3.sh
+++ b/tools/deploy/pi-test-slot-v3.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+TARGET="${2:-primary}"
+COMPONENT="${3:-}"
+GIT_REF="${4:-}"
+PAYLOAD="${5:-}"
+OWNER="${6:-}"
+ARG7="${7:-}"
+ARG8="${8:-}"
+
+STATE_DIR="${PI_TEST_SLOT_STATE_DIR:-/opt/scale-radio/state}"
+STATE_FILE="$STATE_DIR/pi_test_slot_${TARGET}.json"
+LOCK_DIR="$STATE_FILE.lockdir"
+mkdir -p "$STATE_DIR"
+
+python3 - "$ACTION" "$TARGET" "$COMPONENT" "$GIT_REF" "$PAYLOAD" "$OWNER" "$ARG7" "$ARG8" "$STATE_FILE" "$LOCK_DIR" <<'PY'
+import json
+import shutil
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ACTION, TARGET, COMPONENT, GIT_REF, PAYLOAD, OWNER, ARG7, ARG8, STATE_FILE, LOCK_DIR = sys.argv[1:11]
+state_path = Path(STATE_FILE)
+lock_path = Path(LOCK_DIR)
+now = int(time.time())
+
+
+def iso(ts: int) -> str:
+    return datetime.fromtimestamp(ts, timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def load_state():
+    if not state_path.exists():
+        return None
+    return json.loads(state_path.read_text(encoding='utf-8'))
+
+
+def save_state(state):
+    state_path.write_text(json.dumps(state, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+
+
+def release_lockdir():
+    if lock_path.exists():
+        shutil.rmtree(lock_path)
+
+
+def exit_with(code: int, message: str):
+    print(message)
+    raise SystemExit(code)
+
+
+try:
+    lock_path.mkdir()
+except FileExistsError:
+    exit_with(91, f'target-slot-lock-busy target={TARGET}')
+
+try:
+    state = load_state()
+    state_name = (state or {}).get('state', 'free')
+    lease_expires_at = (state or {}).get('lease_expires_at_epoch')
+    expired = bool(lease_expires_at and lease_expires_at < now)
+
+    if ACTION == 'status':
+        if not state:
+            print(json.dumps({'target': TARGET, 'state': 'free'}, indent=2))
+            raise SystemExit(0)
+        print(json.dumps(state, indent=2, sort_keys=True))
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-deploy':
+        hold_minutes = int(ARG7 or '240')
+        if state and state_name in ('deploying', 'test_open', 'rollback_running', 'blocked') and not expired:
+            exit_with(10, f'target-not-free target={TARGET} state={state_name}')
+        lease_until = now + hold_minutes * 60
+        save_state({
+            'target': TARGET,
+            'state': 'deploying',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': now,
+            'acquired_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'acquired-deploy-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-test-open':
+        hold_minutes = int(ARG7 or '240')
+        lease_until = now + hold_minutes * 60
+        if not state:
+            exit_with(12, f'no-active-slot target={TARGET}')
+        save_state({
+            'target': TARGET,
+            'state': 'test_open',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'test_opened_at_epoch': now,
+            'test_opened_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+        })
+        print(f'marked-test-open target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'acquire-rollback':
+        if not state:
+            exit_with(13, f'no-slot-to-rollback target={TARGET}')
+        if state_name not in ('deploying', 'test_open', 'blocked') and not expired:
+            exit_with(14, f'rollback-not-allowed target={TARGET} state={state_name}')
+        if state.get('component') and state.get('component') != COMPONENT:
+            exit_with(15, f'rollback-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+        if state_name != 'blocked' and state.get('git_ref') and state.get('git_ref') != GIT_REF and not expired:
+            exit_with(18, f'rollback-git-ref-mismatch target={TARGET} state_git_ref={state.get("git_ref")} requested_git_ref={GIT_REF}')
+        lease_until = now + 60 * 60
+        save_state({
+            'target': TARGET,
+            'state': 'rollback_running',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'acquired_at_epoch': state.get('acquired_at_epoch', now),
+            'acquired_at': state.get('acquired_at', iso(now)),
+            'rollback_started_at_epoch': now,
+            'rollback_started_at': iso(now),
+            'lease_expires_at_epoch': lease_until,
+            'lease_expires_at': iso(lease_until),
+            'previous_state': state_name,
+            'recovered_from_git_ref': state.get('git_ref'),
+        })
+        print(f'acquired-rollback-slot target={TARGET} component={COMPONENT} git_ref={GIT_REF} payload={PAYLOAD}')
+        raise SystemExit(0)
+
+    if ACTION == 'mark-blocked':
+        reason = ARG7 or 'unspecified'
+        save_state({
+            'target': TARGET,
+            'state': 'blocked',
+            'component': COMPONENT,
+            'git_ref': GIT_REF,
+            'payload': PAYLOAD,
+            'owner': OWNER,
+            'blocked_at_epoch': now,
+            'blocked_at': iso(now),
+            'reason': reason,
+        })
+        print(f'marked-blocked target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    if ACTION == 'release':
+        reason = ARG7 or 'released'
+        force = (ARG8 or '').lower() in ('1', 'true', 'yes', 'force')
+        if not state:
+            print(f'already-free target={TARGET}')
+            raise SystemExit(0)
+        if not force:
+            if state.get('component') and COMPONENT and state.get('component') != COMPONENT:
+                exit_with(16, f'release-component-mismatch target={TARGET} state_component={state.get("component")} requested_component={COMPONENT}')
+            if state.get('git_ref') and GIT_REF and state.get('git_ref') != GIT_REF:
+                exit_with(17, f'release-git-ref-mismatch target={TARGET} state_git_ref={state.get("git_ref")} requested_git_ref={GIT_REF}')
+        state_path.unlink(missing_ok=True)
+        print(f'released-slot target={TARGET} reason={reason}')
+        raise SystemExit(0)
+
+    exit_with(2, f'unsupported-action action={ACTION}')
+finally:
+    release_lockdir()
+PY

--- a/tools/deploy/sr-deploy-wrapper-v2.sh
+++ b/tools/deploy/sr-deploy-wrapper-v2.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+COMPONENT="${2:-}"
+PAYLOAD="${3:-}"
+REPO_ROOT="${4:-${GITHUB_WORKSPACE:-}}"
+
+if [[ -z "$ACTION" || -z "$COMPONENT" || -z "$PAYLOAD" || -z "$REPO_ROOT" ]]; then
+  echo "Usage: sr-deploy <deploy|rollback> <component> <payload> <repo_root>"
+  exit 1
+fi
+
+resolve_bridge_payload() {
+  local requested="$1"
+  local payload_root="$REPO_ROOT/components/scale-radio-bridge/payload"
+  if [[ -d "$payload_root/$requested" ]]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+
+  case "$requested" in
+    current_dev)
+      if [[ -d "$payload_root/023_db_cache_r1" ]]; then
+        echo "SR_BRIDGE: resolving payload alias current_dev -> 023_db_cache_r1" >&2
+        printf '%s\n' "023_db_cache_r1"
+        return 0
+      fi
+      ;;
+    current)
+      if [[ -d "$payload_root/022c2_stable" ]]; then
+        echo "SR_BRIDGE: resolving payload alias current -> 022c2_stable" >&2
+        printf '%s\n' "022c2_stable"
+        return 0
+      fi
+      ;;
+  esac
+
+  echo "SR_BRIDGE: unresolved payload alias $requested under $payload_root" >&2
+  exit 2
+}
+
+case "$COMPONENT" in
+  bridge)
+    BASE="$REPO_ROOT/components/scale-radio-bridge/deploy_candidates"
+    APPLY="$BASE/apply_payload_v2.sh"
+    HEALTH="$BASE/healthcheck_runtime_v2.sh"
+    REMOVE="$BASE/remove_active_v2.sh"
+    RESOLVED_PAYLOAD="$(resolve_bridge_payload "$PAYLOAD")"
+    ;;
+  *)
+    echo "Unsupported component: $COMPONENT"
+    exit 2
+    ;;
+esac
+
+case "$ACTION" in
+  deploy)
+    bash "$APPLY" "$RESOLVED_PAYLOAD"
+    bash "$HEALTH" "$RESOLVED_PAYLOAD"
+    ;;
+  rollback)
+    bash "$REMOVE" "$RESOLVED_PAYLOAD"
+    ;;
+  *)
+    echo "Unsupported action: $ACTION"
+    exit 2
+    ;;
+esac

--- a/tools/governance/autonomous_delivery_matrix_v3.json
+++ b/tools/governance/autonomous_delivery_matrix_v3.json
@@ -1,0 +1,35 @@
+{
+  "components": {
+    "bridge": {
+      "auto_delivery_supported": true,
+      "default_git_ref": "dev/bridge",
+      "default_payload": "current_dev",
+      "deploy_workflow": "component-test-deploy-v8.yml",
+      "rollback_workflow": "component-test-rollback-v8.yml"
+    },
+    "tuner": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "starter": {
+      "auto_delivery_supported": false,
+      "reason": "starter repo truth and deploy contract remain unresolved"
+    },
+    "autoswitch": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "fun-line": {
+      "auto_delivery_supported": false,
+      "reason": "deploy contract not yet normalized"
+    },
+    "hardware": {
+      "auto_delivery_supported": false,
+      "reason": "non-deploy payload lane"
+    },
+    "system-integration": {
+      "auto_delivery_supported": false,
+      "reason": "control-plane lane"
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the first real Bridge deploy blockers found during the live Pi workflow test.

Included:
- `tools/deploy/sr-deploy-wrapper-v2.sh`
- `tools/deploy/pi-test-slot-v2.sh`
- `.github/workflows/component-test-deploy-v8.yml`
- `.github/workflows/component-test-rollback-v8.yml`
- `.github/workflows/component-test-release-slot-v2.yml`
- `.github/workflows/autonomous-delivery-orchestrator-v3.yml`
- `tools/governance/autonomous_delivery_matrix_v3.json`

What this fixes:
1. Bridge deploys from `dev/bridge` can now use the governed pointer `current_dev` even when the branch payload tree does not expose a literal `payload/current_dev/` directory.
   - the v2 wrapper resolves `current_dev -> 023_db_cache_r1`
   - it also resolves `current -> 022c2_stable`
2. Failure rollback can now start from a target state of `deploying`.
   - this fixes the dead-end seen in the live failure path where deploy failed before `test_open` and rollback was then refused by the slot controller
3. The autonomous delivery path is aligned to the new v8 Bridge deploy/rollback workflow generation.

Why this matters:
- the first live Bridge deploy test exposed a real repo/runtime mismatch rather than an operator mistake
- `component-test-deploy-v7` assumed a literal `current_dev` Bridge payload directory on `dev/bridge`
- the failure path then left the Pi slot stuck in `deploying` because rollback acquisition did not allow that state

What still needs manual validation after merge:
- run `component-test-release-slot-v1` or `v2` once with force to clear the currently stuck `primary` slot from the earlier failed run
- then run `component-test-deploy-v8` with:
  - `git_ref=dev/bridge`
  - `component=bridge`
  - `payload=current_dev`
  - `target=primary`
  - `test_hold_minutes=240`

Truthfulness note:
- this PR fixes the repo-side deploy contract for the tested Bridge case
- it does not claim successful Pi validation yet; that still needs the next real workflow run
