### PR TITLE
Add manual tuner deploy lane and update SI/tuner truth

### DIFF
--- a/.github/workflows/component-test-deploy-v10.yml
+++ b/.github/workflows/component-test-deploy-v10.yml
@@ -1,0 +1,95 @@
+name: component-test-deploy-v10
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component payload and deploy scripts"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to deploy"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+      test_hold_minutes:
+        description: "Minutes to reserve the target for post-deploy testing"
+        required: true
+        default: "240"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  deploy_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow/control-plane repository state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          mkdir -p /data/plugins/user_interface
+          mkdir -p /data/configuration/user_interface
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /data/plugins/user_interface
+          test -w /data/configuration/user_interface
+
+      - name: Acquire target deploy slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-deploy "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Apply selected payload via repo wrapper
+        id: apply_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v3.sh deploy "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Mark target slot as test_open
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-test-open "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "${{ inputs.test_hold_minutes }}"
+
+      - name: Roll back selected payload on failure
+        id: rollback_on_failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}"
+          bash tools/deploy/sr-deploy-wrapper-v3.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful failure rollback
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome == 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy-failure-rollback:${GITHUB_RUN_ID}" "deploy_failed_rollback_completed"
+
+      - name: Mark target slot blocked when deploy/rollback did not complete cleanly
+        if: always() && steps.apply_payload.outcome == 'failure' && steps.rollback_on_failure.outcome != 'success'
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "deploy:${GITHUB_RUN_ID}" "deploy_or_failure_rollback_incomplete"

--- a/.github/workflows/component-test-rollback-v10.yml
+++ b/.github/workflows/component-test-rollback-v10.yml
@@ -1,0 +1,73 @@
+name: component-test-rollback-v10
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref containing the component remove script"
+        required: true
+        default: "dev/bridge"
+      component:
+        description: "Component to roll back"
+        required: true
+        default: "bridge"
+      payload:
+        description: "Payload directory name or governed pointer"
+        required: true
+        default: "current_dev"
+      target:
+        description: "Target Pi slot identifier"
+        required: true
+        default: "primary"
+
+concurrency:
+  group: scale-radio-${{ inputs.target }}-deploy-slot
+  cancel-in-progress: false
+
+jobs:
+  rollback_component:
+    runs-on: [self-hosted, scale-radio, pi]
+    steps:
+      - name: Checkout workflow repo state
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout selected component ref
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.git_ref }}
+          path: target_ref
+
+      - name: Preflight writable paths on runner host
+        shell: bash
+        run: |
+          mkdir -p /opt/scale-radio/state
+          mkdir -p "/opt/scale-radio/removed/${{ inputs.component }}"
+          test -w /opt/scale-radio/state
+          test -w "/opt/scale-radio/removed/${{ inputs.component }}"
+
+      - name: Acquire target rollback slot
+        id: acquire_slot
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh acquire-rollback "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}"
+
+      - name: Roll back selected payload via repo wrapper
+        id: rollback_payload
+        shell: bash
+        run: |
+          bash tools/deploy/sr-deploy-wrapper-v3.sh rollback "${{ inputs.component }}" "${{ inputs.payload }}" "$GITHUB_WORKSPACE/target_ref"
+
+      - name: Release target slot after successful rollback
+        if: success()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh release "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_completed"
+
+      - name: Mark target slot blocked on rollback failure
+        if: failure()
+        shell: bash
+        run: |
+          bash tools/deploy/pi-test-slot-v3.sh mark-blocked "${{ inputs.target }}" "${{ inputs.component }}" "${{ inputs.git_ref }}" "${{ inputs.payload }}" "rollback:${GITHUB_RUN_ID}" "rollback_incomplete"

--- a/components/scale-radio-tuner/deploy_candidates/apply_payload_v1.sh
+++ b/components/scale-radio-tuner/deploy_candidates/apply_payload_v1.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAYLOAD_NAME="${1:-}"
+if [[ -z "$PAYLOAD_NAME" ]]; then
+  echo "SR_TUNER: missing payload name"
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPONENT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PAYLOAD_DIR="$COMPONENT_ROOT/payload/${PAYLOAD_NAME}"
+LIVE_DIR="/data/plugins/user_interface/radio_scale_peppy"
+CONFIG_DIR="/data/configuration/user_interface/radio_scale_peppy"
+ARCHIVE_ROOT="/opt/scale-radio/removed/tuner"
+STATE_DIR="/opt/scale-radio/state"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$STATE_DIR" "$ARCHIVE_ROOT"
+echo "tuner_apply_${PAYLOAD_NAME}" > "$STATE_DIR/tuner.last_phase"
+
+if [[ ! -f "$PAYLOAD_DIR/index.js" ]]; then
+  echo "SR_TUNER: missing payload index.js at $PAYLOAD_DIR"
+  exit 2
+fi
+if [[ ! -f "$PAYLOAD_DIR/run_radio_scale.sh" ]]; then
+  echo "SR_TUNER: missing payload launcher run_radio_scale.sh at $PAYLOAD_DIR"
+  exit 2
+fi
+if [[ ! -f "$PAYLOAD_DIR/systemd/scale_fm_renderer.service" ]]; then
+  echo "SR_TUNER: missing renderer service unit at $PAYLOAD_DIR/systemd/scale_fm_renderer.service"
+  exit 2
+fi
+
+if [[ -d "$LIVE_DIR" ]]; then
+  mv "$LIVE_DIR" "$ARCHIVE_ROOT/live.before_${PAYLOAD_NAME}.${TIMESTAMP}"
+fi
+if [[ -d "$CONFIG_DIR" ]]; then
+  mv "$CONFIG_DIR" "$ARCHIVE_ROOT/config.before_${PAYLOAD_NAME}.${TIMESTAMP}"
+fi
+
+mkdir -p "$(dirname "$LIVE_DIR")"
+mkdir -p "$LIVE_DIR"
+cp -a "$PAYLOAD_DIR"/. "$LIVE_DIR"/
+chmod +x "$LIVE_DIR/run_radio_scale.sh" "$LIVE_DIR/run_renderer_daemon.sh" "$LIVE_DIR/install.sh" "$LIVE_DIR/uninstall.sh" 2>/dev/null || true
+
+if [[ -f "$LIVE_DIR/package.json" ]]; then
+  (cd "$LIVE_DIR" && npm install --omit=dev)
+fi
+
+if [[ -f "$LIVE_DIR/install.sh" ]]; then
+  (cd "$LIVE_DIR" && bash ./install.sh)
+fi
+
+chown -R volumio:volumio "$LIVE_DIR" 2>/dev/null || true
+sudo systemctl restart volumio
+
+for i in $(seq 1 60); do
+  if systemctl is-active --quiet volumio; then
+    break
+  fi
+  sleep 2
+done
+
+if ! systemctl is-active --quiet volumio; then
+  echo "SR_TUNER: volumio did not recover after installing $PAYLOAD_NAME"
+  exit 2
+fi
+
+echo "SR_TUNER: applied Tuner payload $PAYLOAD_NAME"

--- a/components/scale-radio-tuner/deploy_candidates/healthcheck_runtime_v1.sh
+++ b/components/scale-radio-tuner/deploy_candidates/healthcheck_runtime_v1.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAYLOAD_NAME="${1:-unknown}"
+LIVE_DIR="/data/plugins/user_interface/radio_scale_peppy"
+SERVICE_PATH="/etc/systemd/system/scale_fm_renderer.service"
+STATE_DIR="/opt/scale-radio/state"
+mkdir -p "$STATE_DIR"
+echo "tuner_healthcheck_${PAYLOAD_NAME}" > "$STATE_DIR/tuner.last_phase"
+
+required=(
+  "$LIVE_DIR/index.js"
+  "$LIVE_DIR/package.json"
+  "$LIVE_DIR/run_radio_scale.sh"
+  "$LIVE_DIR/run_renderer_daemon.sh"
+  "$LIVE_DIR/UIConfig.json"
+  "$LIVE_DIR/config.json"
+  "$LIVE_DIR/renderer/radio_scale_renderer.py"
+  "$LIVE_DIR/renderer/layered_theme.py"
+  "$LIVE_DIR/systemd/scale_fm_renderer.service"
+  "$LIVE_DIR/node_modules/kew"
+)
+
+for path in "${required[@]}"; do
+  if [[ ! -e "$path" ]]; then
+    echo "SR_TUNER: missing required live path $path"
+    exit 2
+  fi
+done
+
+if [[ ! -f "$SERVICE_PATH" ]]; then
+  echo "SR_TUNER: missing installed renderer service unit $SERVICE_PATH"
+  exit 2
+fi
+
+if ! systemctl is-active --quiet volumio; then
+  echo "SR_TUNER: volumio is not active"
+  exit 2
+fi
+if ! systemctl is-active --quiet volumio-kiosk; then
+  echo "SR_TUNER: volumio-kiosk is not active"
+  exit 2
+fi
+if ! systemctl is-active --quiet scale_fm_renderer.service; then
+  echo "SR_TUNER: scale_fm_renderer.service is not active"
+  exit 2
+fi
+if [[ "$(pgrep -fc chromium || true)" -lt 1 ]]; then
+  echo "SR_TUNER: chromium is not running"
+  exit 2
+fi
+if [[ "$(pgrep -fc Xorg || true)" -lt 1 ]]; then
+  echo "SR_TUNER: Xorg is not running"
+  exit 2
+fi
+
+echo "SR_TUNER: Tuner runtime healthcheck passed for $PAYLOAD_NAME"

--- a/components/scale-radio-tuner/deploy_candidates/remove_active_v1.sh
+++ b/components/scale-radio-tuner/deploy_candidates/remove_active_v1.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PAYLOAD_NAME="${1:-tuner}"
+LIVE_DIR="/data/plugins/user_interface/radio_scale_peppy"
+CONFIG_DIR="/data/configuration/user_interface/radio_scale_peppy"
+ARCHIVE_ROOT="/opt/scale-radio/removed/tuner"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+STATE_DIR="/opt/scale-radio/state"
+mkdir -p "$STATE_DIR" "$ARCHIVE_ROOT"
+echo "tuner_remove_${PAYLOAD_NAME}" > "$STATE_DIR/tuner.last_phase"
+
+REMOVED_LIVE=""
+if [[ -d "$LIVE_DIR" ]]; then
+  REMOVED_LIVE="$ARCHIVE_ROOT/live.${PAYLOAD_NAME}.${TIMESTAMP}"
+  mv "$LIVE_DIR" "$REMOVED_LIVE"
+fi
+if [[ -d "$CONFIG_DIR" ]]; then
+  mv "$CONFIG_DIR" "$ARCHIVE_ROOT/config.${PAYLOAD_NAME}.${TIMESTAMP}"
+fi
+
+if [[ -n "$REMOVED_LIVE" && -f "$REMOVED_LIVE/uninstall.sh" ]]; then
+  (cd "$REMOVED_LIVE" && bash ./uninstall.sh)
+else
+  sudo systemctl disable --now scale_fm_renderer.service || true
+  sudo rm -f /etc/systemd/system/scale_fm_renderer.service || true
+  sudo systemctl daemon-reload || true
+fi
+
+sudo systemctl restart volumio
+
+for i in $(seq 1 60); do
+  if systemctl is-active --quiet volumio; then
+    break
+  fi
+  sleep 2
+done
+
+if ! systemctl is-active --quiet volumio; then
+  echo "SR_TUNER: volumio did not recover after Tuner removal"
+  exit 2
+fi
+
+echo "SR_TUNER: removed active Tuner runtime for $PAYLOAD_NAME"

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -1,0 +1,44 @@
+# SYSTEM INTEGRATION GOVERNANCE INDEX V7
+
+## Purpose
+This file is the current entrypoint for system integration governance, recovery, issue routing, autonomous execution doctrine, and the locked operating model for protected-`main` repo truth.
+
+## Directory roles
+- `contracts/repo/` = canonical governance and operating doctrine
+- `journals/` = factual current-state and append-only change memory
+- `docs/agents/` = agent-facing onboarding and recovery material
+- `tools/governance/` = machine-readable governance support data used by workflows
+
+## Read order
+1. `AGENTS.md`
+2. `contracts/repo/branch_strategy_v2.md`
+3. `contracts/repo/component_artifact_model_v1.md`
+4. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+5. `contracts/repo/release_intake_and_delivery_status_v2.md`
+6. `contracts/repo/component_journal_policy_v2.md`
+7. `contracts/repo/new_component_intake_standard_v2.md`
+8. `contracts/repo/issue_governance_routing_standard_v1.md`
+9. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+10. `contracts/repo/system_integration_escalation_contract_v1.md`
+11. `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+12. `contracts/repo/deploy_target_exclusivity_standard_v1.md`
+13. `contracts/repo/truthful_execution_and_negative_answer_standard_v1.md`
+14. `contracts/repo/git_release_tagging_standard_v1.md`
+15. `docs/agents/system_integration_recovery_onboarding_v7.md`
+16. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+17. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+18. `journals/system-integration-normalization/stream_v6.md`
+
+## Locked operating model
+- the repository remains public until further notice
+- `main` remains the protected truth branch
+- agents and chats work on non-`main` branches
+- deploy/test happens from those branches
+- accepted work merges to `main` only after packaged review and owner acceptance
+- journals, decisions, and streams remain mandatory repo truth
+
+## Working rule
+- governance truth must live in the repo, not only in chat memory
+- system integration changes should leave a trail in governance docs and SI journals
+- new work intake, issue routing, escalation, and autonomous execution must use the governed repo model instead of ad-hoc chat memory
+- when tooling, connector, access, or other technical execution problems block safe completion, agents must escalate and inform instead of improvising or silently creating partial repo truth

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -1,0 +1,143 @@
+# SYSTEM INTEGRATION RECOVERY ONBOARDING V7
+
+## Purpose
+This file is the fast re-entry and handover guide for a replacement system integration / normalization chat.
+
+## Current operating model
+The repository is an issue-driven, workflow-backed control plane.
+Use repo-native issues, labels, workflows, journals, and contracts as the operating system.
+
+## Role to assume
+Assume the role of repository control-plane owner for:
+- governance consistency
+- branch and process consistency
+- workflow and rollback doctrine
+- issue routing and escalation discipline
+- autonomous execution guardrails
+- cross-component normalization
+- repo-truth cleanup where uncertainty still exists
+
+Do not assume deep specialist implementation ownership inside a component unless the repo state clearly requires it.
+
+## Current repo truth snapshot
+- repository: `SH99999/mediastreamer`
+- truth branch: `main`
+- repository visibility: public until further notice
+- active component branches:
+  - `dev/bridge`
+  - `dev/tuner`
+  - `dev/starter`
+  - `dev/autoswitch`
+  - `dev/fun-line`
+  - `dev/hardware`
+- integration-owned exception branch:
+  - `integration/staging`
+- current governance layer includes:
+  - one-click branch rebase workflow
+  - weekly governance report issue workflow
+  - issue-governance routing automation
+  - governance closeout workflow
+  - autonomy/intake/escalation layer
+  - corrected issue-intake normalizer v2
+  - first live governance-loop validation already recorded
+  - target deploy/test exclusivity governance and lock-aware workflows
+  - truthful execution and negative-answer standard
+  - governed Git release-tagging standard
+- current deploy truth snapshot:
+  - bridge deploy and rollback are validated on the target Pi
+  - tuner now has a real repo-driven manual deploy/rollback lane and awaits first Pi validation
+
+## Read order
+1. `contracts/repo/system_integration_governance_index_v7.md`
+2. `AGENTS.md`
+3. `contracts/repo/branch_strategy_v2.md`
+4. `contracts/repo/component_artifact_model_v1.md`
+5. `contracts/repo/naming_and_release_numbering_standard_v1.md`
+6. `contracts/repo/release_intake_and_delivery_status_v2.md`
+7. `contracts/repo/component_journal_policy_v2.md`
+8. `contracts/repo/new_component_intake_standard_v2.md`
+9. `contracts/repo/issue_governance_routing_standard_v1.md`
+10. `contracts/repo/autonomous_execution_and_chat_intake_standard_v1.md`
+11. `contracts/repo/system_integration_escalation_contract_v1.md`
+12. `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+13. `contracts/repo/deploy_target_exclusivity_standard_v1.md`
+14. `contracts/repo/truthful_execution_and_negative_answer_standard_v1.md`
+15. `contracts/repo/git_release_tagging_standard_v1.md`
+16. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+17. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+18. `journals/system-integration-normalization/stream_v6.md`
+19. `journals/scale-radio-bridge/current_state_v1.md`
+20. `journals/scale-radio-tuner/current_state_v2.md`
+
+## Locked operating rules
+- `main` is the protected truth branch and final owner acceptance gate
+- agents and chats work on non-`main` branches
+- deploy/test happens from the working branch
+- accepted work merges to `main` only after packaged review and owner acceptance
+- system integration uses short-lived repo-control-plane branches to `main` by default
+- `integration/staging` is exception-only for temporary integration-owned staging work
+- journals, decisions, and streams are mandatory repo truth and must not be treated as optional paperwork
+- if tooling, connector, access, or execution problems prevent safe completion, escalate and inform instead of improvising, faking completion, or silently mutating partial truth
+- if a connector cannot safely update an existing truth file, use the protected-main replacement-file operating model instead of forcing an unsafe mutation path
+- target deploy/test exclusivity is governed and must be respected before runtime mutation on the Pi
+- an explicit truthful negative answer is always preferred over fabricated progress, implied completion, false confidence, or placeholder delivery
+
+## Key workflows to know immediately
+### Branch and repo health
+- `rebase-dev-and-integration-branches-on-main.yml`
+- `weekly-governance-report-issue.yml`
+- `release-readiness-audit.yml`
+- `repo-health-v3.yml`
+- `governance-health-v2.yml`
+- `component-health-v1.yml`
+
+### Issue governance and queue generation
+- `ensure-governance-labels.yml`
+- `open-decision-issues.yml`
+- `branch-drift-issues.yml`
+- `journal-freshness-issues.yml`
+- `stale-governance-items.yml`
+- `pr-governance-review.yml`
+- `governance-closeout.yml`
+
+### Intake and autonomy
+- `issue-intake-normalizer-v2.yml`
+- `issue-context-enrichment.yml`
+- `system-integration-escalation.yml`
+- `autonomous-delivery-orchestrator-v3.yml`
+- `decision-verification-on-merge.yml`
+- `repo-control-plane-sanity-check.yml`
+- `bootstrap-new-component.yml`
+
+### Component deploy/test workflows still relevant
+- `component-test-deploy-v9.yml`
+- `component-test-rollback-v9.yml`
+- `component-test-release-slot-v3.yml`
+- `component-test-deploy-v10.yml`
+- `component-test-rollback-v10.yml`
+
+## Working rule
+- use the issue-routing model instead of ad-hoc chat-side task memory
+- if work is cross-component or system-wide, escalate automatically to SI/governance
+- if a component is not support-matrix delivery-capable, do not pretend autonomous delivery support exists
+- keep repo-truth cleanup visible in docs, journals, and issues instead of hiding uncertainty
+
+## Current practical priorities
+1. keep the governance and issue control-plane working
+2. keep active branches aligned to `main`
+3. validate the new tuner manual deploy/rollback lane on the target Pi
+4. decide whether tuner can join the autonomous delivery matrix after first Pi validation
+5. resolve repo-truth uncertainty where still open, highest priority:
+   - starter
+   - fun-line
+   - hardware
+
+## Minimum completion condition for a replacement SI chat
+Before changing repo-control-plane truth, the replacement chat should be able to answer:
+- what the current issue-routing model is
+- how escalation is triggered
+- which workflows are operator-facing versus background automation
+- which components are currently delivery-capable
+- which uncertainties are explicitly tracked in repo truth instead of assumed away
+- what to do when safe completion is blocked by tool or connector limitations
+- which stream file is the active SI stream truth

--- a/journals/scale-radio-tuner/current_state_v2.md
+++ b/journals/scale-radio-tuner/current_state_v2.md
@@ -1,0 +1,63 @@
+# CURRENT STATE — scale-radio-tuner
+
+Status note: this v2 file supersedes `current_state_v1.md` as the current tuner deploy-lane addendum.
+
+## Component
+- normalized component name: `scale-radio-tuner`
+- governed artifact pattern: one component with multiple artifacts
+- active artifacts in the currently imported payload:
+  - `Scale FM Overlay`
+  - resident renderer service `scale_fm_renderer.service`
+- artifact still referenced in legacy component truth but not yet normalized in the active deploy lane:
+  - `Scale FM Source`
+- active work lane: `dev/tuner`
+
+## Repo truth
+- component root exists at `components/scale-radio-tuner/`
+- a real imported payload exists at `components/scale-radio-tuner/payload/current/`
+- earlier top-level tuner install/configure/healthcheck hooks were placeholder deploy-contract scaffolding only
+- a real repo-driven deploy candidate lane now exists at:
+  - `components/scale-radio-tuner/deploy_candidates/apply_payload_v1.sh`
+  - `components/scale-radio-tuner/deploy_candidates/healthcheck_runtime_v1.sh`
+  - `components/scale-radio-tuner/deploy_candidates/remove_active_v1.sh`
+- generic deploy wrapper support now exists through `tools/deploy/sr-deploy-wrapper-v3.sh`
+- manual test workflows now exist through:
+  - `.github/workflows/component-test-deploy-v10.yml`
+  - `.github/workflows/component-test-rollback-v10.yml`
+
+## Lifecycle status
+- `payload_complete`
+- `deployment_candidate_started`
+- `deploy_ready`
+- `tested_on_pi_open`
+- `functional_acceptance_open`
+
+## Accepted baseline
+- authoritative overlay/render baseline in repo: `1.10.2`
+- external names:
+  - `Scale FM Overlay`
+  - `Scale FM Source`
+- internal identifiers that must remain stable:
+  - `radio_scale_peppy`
+  - `radio_scale_source`
+  - `scale_fm_renderer.service`
+
+## Current known working behavior
+- tuner payload includes the full `radio_scale_peppy` overlay runtime, renderer Python code, layered Braun HD theme assets, launch scripts, and systemd unit
+- install script provisions Python renderer dependencies and seeds playlist/favourites state
+- deploy lane now installs the payload directly to `/data/plugins/user_interface/radio_scale_peppy`, runs `npm install`, executes the payload install script, and validates the renderer service/runtime path
+- rollback lane archives the active tuner runtime and removes the active renderer service cleanly
+
+## Current gaps
+- the currently normalized deploy lane covers the overlay and resident renderer service only
+- the separate `radio_scale_source` artifact is still not imported as a deployable repo payload in this lane
+- the new manual deploy/rollback lane is not yet validated on the target Pi
+- first-show pointer sweep after boot remains unresolved
+- exit white flashes remain unresolved
+- pointer flicker/jitter is not fully solved
+
+## Repo-normalized next action
+1. run `component-test-deploy-v10` for `component=tuner`, `git_ref=main`, `payload=current`, `target=primary`
+2. validate tuner open/close, renderer service, and rollback on the target Pi
+3. decide whether tuner can enter the autonomous delivery matrix after first Pi validation
+4. import or normalize the separate `radio_scale_source` artifact if the governed component must again ship both overlay and source as one deploy lane

--- a/journals/scale-radio-tuner/stream_v2.md
+++ b/journals/scale-radio-tuner/stream_v2.md
@@ -1,0 +1,14 @@
+# STREAM — scale-radio-tuner
+
+Status note: this v2 file supersedes `stream_v1.md` as the current tuner stream because the repository now has a real manual deploy/rollback lane for the imported `1.10.2` tuner payload.
+
+## Entries
+- 2026-04-13: Initial repo journal created from legacy tuner status and decision handover.
+- 2026-04-13: Tuner normalized as one component with multiple artifacts rather than separate branches per plugin.
+- 2026-04-13: Authoritative overlay/render baseline recorded as `1.10.2`.
+- 2026-04-13: Repo truth recorded that tuner did not yet have the same repo-driven deploy maturity as bridge.
+- 2026-04-15: Verified that the imported tuner payload already exists in repo at `components/scale-radio-tuner/payload/current/` and contains the `radio_scale_peppy` overlay runtime, renderer scripts, and `scale_fm_renderer.service`.
+- 2026-04-15: Added real deploy candidate scripts under `components/scale-radio-tuner/deploy_candidates/` for apply, runtime healthcheck, and rollback.
+- 2026-04-15: Added generic wrapper support for tuner via `tools/deploy/sr-deploy-wrapper-v3.sh`.
+- 2026-04-15: Added manual workflow generation `component-test-deploy-v10.yml` and `component-test-rollback-v10.yml` so tuner can now enter the same lock-aware Pi test-slot model as bridge.
+- 2026-04-15: Kept the separate `radio_scale_source` artifact explicit as a remaining deploy-lane gap instead of pretending the full multi-artifact tuner contract is already imported.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
@@ -1,0 +1,112 @@
+# COMPONENT STATUS — system_integration_normalization
+
+Status note: this v8 file supersedes the earlier v7 deploy-exclusivity addendum as the current SI/N status addendum.
+
+## 1. Scope
+- component name: system_integration_normalization
+- legacy names / aliases: SI/N, integration chat, normalization lane
+- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, issue routing, escalation discipline, autonomous execution guardrails, cross-component normalization, protected-main truth maintenance operating model, target deploy/test exclusivity rules
+- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware implementation, unsupported component delivery automation
+
+## 2. Current Functional Status
+- what currently works:
+  - governance, issue-routing, and reporting workflows exist on `main`
+  - one-click branch rebase exists for all current and future `dev/*` and `integration/*` branches
+  - weekly governance report issues are generated from repo truth
+  - open decisions, branch drift, and journal freshness can become governance-routed issues automatically
+  - PR governance review and governance closeout workflows are active
+  - new governed components can be bootstrapped via workflow
+  - release-readiness audit exists as a manual gate
+  - an autonomous execution doctrine and SI escalation contract exist in repo form
+  - a protected-main truth maintenance operating model exists for safe handling of connector mutation limits
+  - a target deploy/test exclusivity contract and lock-aware workflow family exist on `main`
+  - bridge deploy and rollback are now validated on the target Pi
+  - tuner now has a real repo-driven manual deploy/rollback lane through `sr-deploy-wrapper-v3.sh` plus `component-test-deploy-v10.yml` / `component-test-rollback-v10.yml`
+- what partially works:
+  - autonomous delivery is still support-matrix limited and not yet broad across all active components
+  - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts may still be required in some cases
+  - tuner deploy normalization currently covers the overlay/runtime/service lane only; the separate `radio_scale_source` artifact is still not normalized as a deployable repo payload
+- what is broken:
+  - unsupported components still cannot use autonomous delivery and must still escalate or no-op safely
+- what was tested:
+  - governance reporting and routing layers were merged and are available on `main`
+  - project auto-add and project views were confirmed to work with the governance label model
+  - branch creation and new-file repo-truth updates through the connector are working
+  - bridge lock-aware deploy and rollback path are now validated on the real Pi
+- what is untested:
+  - broader autonomous delivery beyond the current support matrix
+  - the new tuner manual deploy/rollback lane on the target Pi
+  - a future connector path for safe in-place mutation of all protected truth files
+
+## 3. Repository Mapping
+- correct component path in repo: `journals/system-integration-normalization/`
+- correct truth contracts: `contracts/repo/`
+- correct support data path: `tools/governance/`
+- correct branch model: `main` for truth; short-lived repo-control-plane branches for SI changes; `integration/staging` as an exception-only branch
+
+## 4. Locked Decisions
+### DEC-SIN-12
+- decision: issue routing is label-based and one central GitHub Project is used instead of one project per component.
+- rationale: low owner overhead and scalable routing.
+- impact: governance issues route by label, not by assignee.
+
+### DEC-SIN-13
+- decision: autonomous execution must minimize recurring owner administration and use governed repo workflows and repo truth.
+- rationale: the repo is becoming the operating system for the project.
+- impact: workflows and docs must favor auto-routing, auto-reporting, and safe escalation.
+
+### DEC-SIN-14
+- decision: cross-component and system-wide impact must escalate automatically to system integration / governance.
+- rationale: chat memory is not a safe integration bus.
+- impact: escalation workflows and labels are required.
+
+### DEC-SIN-15
+- decision: autonomous delivery must be support-matrix based and conservative.
+- rationale: not all components have normalized deploy/rollback contracts yet.
+- impact: unsupported components must escalate or no-op safely instead of pretending delivery support exists.
+
+### DEC-SIN-16
+- decision: the repository remains public until further notice while `main` stays protected as the truth branch.
+- rationale: low-cost operation is currently preferred over private-repo administration while protected `main` still preserves truth discipline.
+- impact: work happens in public branches and PRs; accepted truth still gates on protected `main`.
+
+### DEC-SIN-17
+- decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
+- rationale: this minimizes branch clutter, truth ambiguity, and owner click overhead.
+- impact: SI changes should normally ship as packaged PRs from temporary branches.
+
+### DEC-SIN-18
+- decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
+- rationale: false completion is more dangerous than an explicit blocker in a governed repo.
+- impact: blocking technical issues become visible repo/integration risks instead of hidden drift.
+
+### DEC-SIN-19
+- decision: if the connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
+- rationale: protected truth must remain accurate even when the mutation surface is limited.
+- impact: replacement artifacts such as `ag_new.txt` are allowed as an exception path when clearly documented.
+
+### DEC-SIN-20
+- decision: one target Pi may have only one active deploy/test slot at a time; no other deploy may run while that slot is occupied.
+- rationale: parallel deploys destroy test validity and make rollback anchors ambiguous.
+- impact: deploy/test/rollback workflows must respect target-slot state such as `free`, `deploying`, `test_open`, `rollback_running`, and `blocked`.
+
+## 5. Open Decisions
+- when tuner can enter the autonomous delivery support matrix after first Pi validation
+- when additional components beyond bridge and tuner become delivery-capable in the autonomous support matrix
+- whether the repository should later move to private visibility if the cost/risk tradeoff changes
+- whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
+
+## 6. Runtime / Deployment Notes
+- current validated deploy/rollback reference component: Bridge
+- current repo-driven manual deploy candidates:
+  - Bridge
+  - Tuner overlay/runtime/service lane
+- delivery support matrix on `main` remains conservative until tuner is validated on the target Pi
+- owner remains the final onsite acceptance gate before stable truth is merged to `main`
+- tuner still has one explicit contract gap: the separate `radio_scale_source` artifact is not yet normalized inside the new deploy lane
+
+## 7. Next Recommended Steps
+1. run the first tuner Pi validation via `component-test-deploy-v10`
+2. validate tuner rollback via `component-test-rollback-v10`
+3. decide whether tuner can enter the autonomous delivery matrix after successful Pi validation
+4. normalize the next component wrapper contract after tuner proves the lane

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -1,0 +1,38 @@
+# STREAM — system_integration_normalization
+
+Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream because tuner now has a real repo-driven manual deploy/rollback lane after Bridge proved the lock-aware runtime path on the Pi.
+
+## Entries
+### 2026-04-12 / main / PR #26 merged
+- governance v2 docs landed on `main`
+- the first repo-native SI/N status and decision files were added
+- purpose: move SI/N truth out of placeholder docs and into repo form
+
+### 2026-04-13 to 2026-04-14 / main / merged governance sequence
+- branch doctrine, artifact model, naming/release numbering, SI recovery onboarding, issue governance, weekly governance reports, autonomy layer, escalation workflows, and repo sanity controls were added across the governance build-out sequence
+- purpose: convert the repository into an issue-driven, workflow-backed control plane
+
+### 2026-04-14 / main / PR #62 merged
+- protected-main truth maintenance operating model was added
+- SI status v6, decisions v6, and stream v2 were added
+- purpose: align SI truth to the locked public + protected-main operating model
+
+### 2026-04-15 / main / follow-up SI truth alignment
+- truthful execution and negative-answer rule was added to governed repo doctrine
+- Git release tagging standard was added
+- governance index and recovery onboarding were refreshed to the active SI truth chain
+- purpose: keep repo truth trustworthy and keep replacement SI chats on the active document chain
+
+### 2026-04-15 / main / Bridge validation follow-up
+- bridge deploy pointer resolution and lock-aware rollback recovery fixes landed through PR #67
+- bridge deploy and rollback were then validated on the target Pi
+- purpose: prove the lock-aware deploy/test slot model with one real reference component
+
+### 2026-04-15 / tuner-deploy-lane-1 / current branch
+- verified that the imported tuner payload already exists in repo at `components/scale-radio-tuner/payload/current/`
+- replaced the old placeholder tuner deploy hooks with real deploy candidate scripts under `components/scale-radio-tuner/deploy_candidates/`
+- added `tools/deploy/sr-deploy-wrapper-v3.sh` so bridge and tuner can both use the generic wrapper family
+- added `component-test-deploy-v10.yml` and `component-test-rollback-v10.yml` for manual tuner validation on the target Pi
+- updated tuner current-state and stream truth to reflect the new deploy lane and the still-open `radio_scale_source` gap
+- updated SI status to reflect that bridge is validated and tuner is now a real manual deploy candidate awaiting Pi validation
+- purpose: move the next active component from legacy placeholder deploy doctrine into an actually executable repo-driven lane without pretending Pi validation already happened

--- a/tools/deploy/sr-deploy-wrapper-v3.sh
+++ b/tools/deploy/sr-deploy-wrapper-v3.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+COMPONENT="${2:-}"
+PAYLOAD="${3:-}"
+REPO_ROOT="${4:-${GITHUB_WORKSPACE:-}}"
+
+if [[ -z "$ACTION" || -z "$COMPONENT" || -z "$PAYLOAD" || -z "$REPO_ROOT" ]]; then
+  echo "Usage: sr-deploy <deploy|rollback> <component> <payload> <repo_root>"
+  exit 1
+fi
+
+resolve_bridge_payload() {
+  local requested="$1"
+  local payload_root="$REPO_ROOT/components/scale-radio-bridge/payload"
+  if [[ -d "$payload_root/$requested" ]]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+  case "$requested" in
+    current_dev)
+      if [[ -d "$payload_root/023_db_cache_r1" ]]; then
+        echo "SR_BRIDGE: resolving payload alias current_dev -> 023_db_cache_r1" >&2
+        printf '%s\n' "023_db_cache_r1"
+        return 0
+      fi
+      ;;
+    current)
+      if [[ -d "$payload_root/022c2_stable" ]]; then
+        echo "SR_BRIDGE: resolving payload alias current -> 022c2_stable" >&2
+        printf '%s\n' "022c2_stable"
+        return 0
+      fi
+      ;;
+  esac
+  echo "SR_BRIDGE: unresolved payload alias $requested under $payload_root" >&2
+  exit 2
+}
+
+resolve_tuner_payload() {
+  local requested="$1"
+  local payload_root="$REPO_ROOT/components/scale-radio-tuner/payload"
+  if [[ -d "$payload_root/$requested" ]]; then
+    printf '%s\n' "$requested"
+    return 0
+  fi
+  case "$requested" in
+    current_dev|current)
+      if [[ -d "$payload_root/current" ]]; then
+        echo "SR_TUNER: resolving payload alias $requested -> current" >&2
+        printf '%s\n' "current"
+        return 0
+      fi
+      ;;
+  esac
+  echo "SR_TUNER: unresolved payload alias $requested under $payload_root" >&2
+  exit 2
+}
+
+case "$COMPONENT" in
+  bridge)
+    BASE="$REPO_ROOT/components/scale-radio-bridge/deploy_candidates"
+    APPLY="$BASE/apply_payload_v2.sh"
+    HEALTH="$BASE/healthcheck_runtime_v2.sh"
+    REMOVE="$BASE/remove_active_v2.sh"
+    RESOLVED_PAYLOAD="$(resolve_bridge_payload "$PAYLOAD")"
+    ;;
+  tuner)
+    BASE="$REPO_ROOT/components/scale-radio-tuner/deploy_candidates"
+    APPLY="$BASE/apply_payload_v1.sh"
+    HEALTH="$BASE/healthcheck_runtime_v1.sh"
+    REMOVE="$BASE/remove_active_v1.sh"
+    RESOLVED_PAYLOAD="$(resolve_tuner_payload "$PAYLOAD")"
+    ;;
+  *)
+    echo "Unsupported component: $COMPONENT"
+    exit 2
+    ;;
+esac
+
+case "$ACTION" in
+  deploy)
+    bash "$APPLY" "$RESOLVED_PAYLOAD"
+    bash "$HEALTH" "$RESOLVED_PAYLOAD"
+    ;;
+  rollback)
+    bash "$REMOVE" "$RESOLVED_PAYLOAD"
+    ;;
+  *)
+    echo "Unsupported action: $ACTION"
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
This PR moves tuner from placeholder deploy doctrine to a real repo-driven manual deploy/rollback lane.

Included
- `components/scale-radio-tuner/deploy_candidates/apply_payload_v1.sh`
- `components/scale-radio-tuner/deploy_candidates/healthcheck_runtime_v1.sh`
- `components/scale-radio-tuner/deploy_candidates/remove_active_v1.sh`
- `tools/deploy/sr-deploy-wrapper-v3.sh`
- `.github/workflows/component-test-deploy-v10.yml`
- `.github/workflows/component-test-rollback-v10.yml`
- `journals/scale-radio-tuner/current_state_v2.md`
- `journals/scale-radio-tuner/stream_v2.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
- `journals/system-integration-normalization/stream_v6.md`
- `contracts/repo/system_integration_governance_index_v7.md`
- `docs/agents/system_integration_recovery_onboarding_v7.md`

What changed
1. Verified that the imported tuner payload already exists in repo at `components/scale-radio-tuner/payload/current/`.
2. Replaced the old placeholder top-level tuner deploy hooks with real deploy candidate scripts that:
   - copy the imported tuner payload into `/data/plugins/user_interface/radio_scale_peppy`
   - run `npm install --omit=dev`
   - execute the payload install script
   - validate the runtime and renderer service path
   - archive and remove the active tuner runtime on rollback
3. Extended the generic deploy wrapper family so tuner can use the same lock-aware test-slot model as bridge.
4. Added manual v10 workflows for tuner deploy and rollback.
5. Updated tuner and SI repo truth to state clearly that:
   - bridge deploy and rollback are already validated on the Pi
   - tuner is now deploy-ready as a manual candidate lane
   - the separate `radio_scale_source` artifact is still an explicit gap and is not being faked as part of this lane

Truthfulness note
- this PR does not claim tuner Pi validation yet
- it only claims that tuner now has a real repo-driven manual deploy/rollback lane based on the imported `1.10.2` overlay/runtime/service payload

Recommended next step after merge
- run `component-test-deploy-v10` with:
  - `git_ref=main`
  - `component=tuner`
  - `payload=current`
  - `target=primary`
  - `test_hold_minutes=240`
- then validate tuner runtime and run `component-test-rollback-v10`
