### PR TITLE
Fix tuner workflow defaults for manual runs

### DIFF
--- a/.github/workflows/component-test-deploy-v10.yml
+++ b/.github/workflows/component-test-deploy-v10.yml
@@ -6,15 +6,15 @@ on:
       git_ref:
         description: "Git ref containing the component payload and deploy scripts"
         required: true
-        default: "dev/bridge"
+        default: "main"
       component:
         description: "Component to deploy"
         required: true
-        default: "bridge"
+        default: "tuner"
       payload:
         description: "Payload directory name or governed pointer"
         required: true
-        default: "current_dev"
+        default: "current"
       target:
         description: "Target Pi slot identifier"
         required: true

--- a/.github/workflows/component-test-rollback-v10.yml
+++ b/.github/workflows/component-test-rollback-v10.yml
@@ -6,15 +6,15 @@ on:
       git_ref:
         description: "Git ref containing the component remove script"
         required: true
-        default: "dev/bridge"
+        default: "main"
       component:
         description: "Component to roll back"
         required: true
-        default: "bridge"
+        default: "tuner"
       payload:
         description: "Payload directory name or governed pointer"
         required: true
-        default: "current_dev"
+        default: "current"
       target:
         description: "Target Pi slot identifier"
         required: true


### PR DESCRIPTION
This small follow-up fixes the default values shown in the tuner manual workflows.

Why
- `component-test-deploy-v10.yml` and `component-test-rollback-v10.yml` were copied from the bridge flow
- the workflow logic was correct, but the default input values still showed bridge-oriented defaults
- that creates avoidable click friction and can mislead manual runs

What changed
- `component-test-deploy-v10.yml`
  - `git_ref: main`
  - `component: tuner`
  - `payload: current`
- `component-test-rollback-v10.yml`
  - `git_ref: main`
  - `component: tuner`
  - `payload: current`

No deploy logic changed.
Only the manual-dispatch defaults were corrected.
