### PR TITLE
Formalize tuner Pi validation in tuner and SI journals

### DIFF
--- a/journals/scale-radio-tuner/current_state_v2.md
+++ b/journals/scale-radio-tuner/current_state_v2.md
@@ -1,6 +1,6 @@
 # CURRENT STATE — scale-radio-tuner
 
-Status note: this v2 file supersedes `current_state_v1.md` as the current tuner deploy-lane addendum.
+Status note: this v2 file remains the current tuner deploy-lane truth and is updated here after successful target-Pi validation.
 
 ## Component
 - normalized component name: `scale-radio-tuner`
@@ -29,7 +29,9 @@ Status note: this v2 file supersedes `current_state_v1.md` as the current tuner 
 - `payload_complete`
 - `deployment_candidate_started`
 - `deploy_ready`
-- `tested_on_pi_open`
+- `deploy_validated_on_pi`
+- `rollback_validated_on_pi`
+- `manual_runtime_validation_passed`
 - `functional_acceptance_open`
 
 ## Accepted baseline
@@ -45,19 +47,19 @@ Status note: this v2 file supersedes `current_state_v1.md` as the current tuner 
 ## Current known working behavior
 - tuner payload includes the full `radio_scale_peppy` overlay runtime, renderer Python code, layered Braun HD theme assets, launch scripts, and systemd unit
 - install script provisions Python renderer dependencies and seeds playlist/favourites state
-- deploy lane now installs the payload directly to `/data/plugins/user_interface/radio_scale_peppy`, runs `npm install`, executes the payload install script, and validates the renderer service/runtime path
+- deploy lane installs the payload directly to `/data/plugins/user_interface/radio_scale_peppy`, runs `npm install`, executes the payload install script, and validates the renderer service/runtime path
 - rollback lane archives the active tuner runtime and removes the active renderer service cleanly
+- both deploy and rollback are now validated on the target Pi through the governed lock-aware workflow lane
 
 ## Current gaps
 - the currently normalized deploy lane covers the overlay and resident renderer service only
 - the separate `radio_scale_source` artifact is still not imported as a deployable repo payload in this lane
-- the new manual deploy/rollback lane is not yet validated on the target Pi
 - first-show pointer sweep after boot remains unresolved
 - exit white flashes remain unresolved
 - pointer flicker/jitter is not fully solved
+- autonomous delivery support for tuner is still an explicit follow-up decision and is not promoted automatically by this update
 
 ## Repo-normalized next action
-1. run `component-test-deploy-v10` for `component=tuner`, `git_ref=main`, `payload=current`, `target=primary`
-2. validate tuner open/close, renderer service, and rollback on the target Pi
-3. decide whether tuner can enter the autonomous delivery matrix after first Pi validation
-4. import or normalize the separate `radio_scale_source` artifact if the governed component must again ship both overlay and source as one deploy lane
+1. decide whether tuner should now enter the autonomous delivery matrix after successful manual Pi validation
+2. import or normalize the separate `radio_scale_source` artifact if the governed component must again ship both overlay and source as one deploy lane
+3. normalize the next component onto the same repo-driven deploy/rollback model after bridge and tuner

--- a/journals/scale-radio-tuner/stream_v2.md
+++ b/journals/scale-radio-tuner/stream_v2.md
@@ -12,3 +12,6 @@ Status note: this v2 file supersedes `stream_v1.md` as the current tuner stream 
 - 2026-04-15: Added generic wrapper support for tuner via `tools/deploy/sr-deploy-wrapper-v3.sh`.
 - 2026-04-15: Added manual workflow generation `component-test-deploy-v10.yml` and `component-test-rollback-v10.yml` so tuner can now enter the same lock-aware Pi test-slot model as bridge.
 - 2026-04-15: Kept the separate `radio_scale_source` artifact explicit as a remaining deploy-lane gap instead of pretending the full multi-artifact tuner contract is already imported.
+- 2026-04-15: Added non-interactive privileged execution support for tuner deploy/rollback through `PI_SUDO_PASSWORD` on the runner.
+- 2026-04-15: Manual tuner deploy succeeded on the target Pi.
+- 2026-04-15: Manual tuner rollback succeeded on the target Pi.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
@@ -1,6 +1,6 @@
 # COMPONENT STATUS — system_integration_normalization
 
-Status note: this v8 file supersedes the earlier v7 deploy-exclusivity addendum as the current SI/N status addendum.
+Status note: this v8 file remains the current SI/N status addendum and is updated here after successful tuner target-Pi validation.
 
 ## 1. Scope
 - component name: system_integration_normalization
@@ -20,8 +20,8 @@ Status note: this v8 file supersedes the earlier v7 deploy-exclusivity addendum 
   - an autonomous execution doctrine and SI escalation contract exist in repo form
   - a protected-main truth maintenance operating model exists for safe handling of connector mutation limits
   - a target deploy/test exclusivity contract and lock-aware workflow family exist on `main`
-  - bridge deploy and rollback are now validated on the target Pi
-  - tuner now has a real repo-driven manual deploy/rollback lane through `sr-deploy-wrapper-v3.sh` plus `component-test-deploy-v10.yml` / `component-test-rollback-v10.yml`
+  - bridge deploy and rollback are validated on the target Pi
+  - tuner deploy and rollback are now also validated on the target Pi through the manual lock-aware workflow lane
 - what partially works:
   - autonomous delivery is still support-matrix limited and not yet broad across all active components
   - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts may still be required in some cases
@@ -32,10 +32,10 @@ Status note: this v8 file supersedes the earlier v7 deploy-exclusivity addendum 
   - governance reporting and routing layers were merged and are available on `main`
   - project auto-add and project views were confirmed to work with the governance label model
   - branch creation and new-file repo-truth updates through the connector are working
-  - bridge lock-aware deploy and rollback path are now validated on the real Pi
+  - bridge lock-aware deploy and rollback path are validated on the real Pi
+  - tuner lock-aware deploy and rollback path are validated on the real Pi
 - what is untested:
   - broader autonomous delivery beyond the current support matrix
-  - the new tuner manual deploy/rollback lane on the target Pi
   - a future connector path for safe in-place mutation of all protected truth files
 
 ## 3. Repository Mapping
@@ -91,22 +91,20 @@ Status note: this v8 file supersedes the earlier v7 deploy-exclusivity addendum 
 - impact: deploy/test/rollback workflows must respect target-slot state such as `free`, `deploying`, `test_open`, `rollback_running`, and `blocked`.
 
 ## 5. Open Decisions
-- when tuner can enter the autonomous delivery support matrix after first Pi validation
+- when tuner should enter the autonomous delivery support matrix after its now-successful manual Pi validation
 - when additional components beyond bridge and tuner become delivery-capable in the autonomous support matrix
 - whether the repository should later move to private visibility if the cost/risk tradeoff changes
 - whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
 
 ## 6. Runtime / Deployment Notes
-- current validated deploy/rollback reference component: Bridge
-- current repo-driven manual deploy candidates:
+- current validated deploy/rollback reference components:
   - Bridge
   - Tuner overlay/runtime/service lane
-- delivery support matrix on `main` remains conservative until tuner is validated on the target Pi
+- delivery support matrix on `main` remains conservative until tuner is explicitly promoted by decision
 - owner remains the final onsite acceptance gate before stable truth is merged to `main`
 - tuner still has one explicit contract gap: the separate `radio_scale_source` artifact is not yet normalized inside the new deploy lane
 
 ## 7. Next Recommended Steps
-1. run the first tuner Pi validation via `component-test-deploy-v10`
-2. validate tuner rollback via `component-test-rollback-v10`
-3. decide whether tuner can enter the autonomous delivery matrix after successful Pi validation
-4. normalize the next component wrapper contract after tuner proves the lane
+1. decide whether tuner should now enter the autonomous delivery matrix
+2. normalize the separate `radio_scale_source` artifact if tuner must again ship both overlay and source as one governed lane
+3. normalize the next component wrapper contract after bridge and tuner

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -28,11 +28,16 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - bridge deploy and rollback were then validated on the target Pi
 - purpose: prove the lock-aware deploy/test slot model with one real reference component
 
-### 2026-04-15 / tuner-deploy-lane-1 / current branch
+### 2026-04-15 / main / Tuner deploy-lane build-out
 - verified that the imported tuner payload already exists in repo at `components/scale-radio-tuner/payload/current/`
 - replaced the old placeholder tuner deploy hooks with real deploy candidate scripts under `components/scale-radio-tuner/deploy_candidates/`
 - added `tools/deploy/sr-deploy-wrapper-v3.sh` so bridge and tuner can both use the generic wrapper family
 - added `component-test-deploy-v10.yml` and `component-test-rollback-v10.yml` for manual tuner validation on the target Pi
 - updated tuner current-state and stream truth to reflect the new deploy lane and the still-open `radio_scale_source` gap
-- updated SI status to reflect that bridge is validated and tuner is now a real manual deploy candidate awaiting Pi validation
+- updated SI status to reflect that bridge is validated and tuner became a real manual deploy candidate
 - purpose: move the next active component from legacy placeholder deploy doctrine into an actually executable repo-driven lane without pretending Pi validation already happened
+
+### 2026-04-15 / main / Tuner validation follow-up
+- added non-interactive privileged execution support for tuner through `PI_SUDO_PASSWORD`
+- tuner deploy and tuner rollback both completed successfully on the target Pi
+- purpose: establish tuner as the second validated manual deploy/rollback lane while keeping autonomous promotion as a separate explicit decision


### PR DESCRIPTION
This PR records the now-successful tuner target-Pi validation in the active repo-truth files.

Updated
- `journals/scale-radio-tuner/current_state_v2.md`
- `journals/scale-radio-tuner/stream_v2.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
- `journals/system-integration-normalization/stream_v6.md`

What is formalized
- tuner deploy succeeded on the target Pi
- tuner rollback succeeded on the target Pi
- tuner now joins bridge as a validated manual deploy/rollback lane
- tuner is not auto-promoted into the autonomous delivery matrix by this PR
- the separate `radio_scale_source` artifact remains an explicit deploy-lane gap

Why this matters
- current repo truth should reflect validated runtime reality, not only repo-side readiness
- the next decision can now focus cleanly on whether tuner should enter the autonomous delivery support matrix
