### PR TITLE
Enable tuner in autonomous delivery matrix and update repo truth

### DIFF
--- a/journals/scale-radio-tuner/current_state_v2.md
+++ b/journals/scale-radio-tuner/current_state_v2.md
@@ -1,6 +1,6 @@
 # CURRENT STATE — scale-radio-tuner
 
-Status note: this v2 file remains the current tuner deploy-lane truth and is updated here after successful target-Pi validation.
+Status note: this v2 file remains the current tuner deploy-lane truth and is updated here after successful target-Pi validation and autonomous-delivery promotion.
 
 ## Component
 - normalized component name: `scale-radio-tuner`
@@ -24,6 +24,7 @@ Status note: this v2 file remains the current tuner deploy-lane truth and is upd
 - manual test workflows now exist through:
   - `.github/workflows/component-test-deploy-v10.yml`
   - `.github/workflows/component-test-rollback-v10.yml`
+- tuner is now enabled in `tools/governance/autonomous_delivery_matrix_v3.json`
 
 ## Lifecycle status
 - `payload_complete`
@@ -32,6 +33,7 @@ Status note: this v2 file remains the current tuner deploy-lane truth and is upd
 - `deploy_validated_on_pi`
 - `rollback_validated_on_pi`
 - `manual_runtime_validation_passed`
+- `autonomous_delivery_enabled`
 - `functional_acceptance_open`
 
 ## Accepted baseline
@@ -50,6 +52,7 @@ Status note: this v2 file remains the current tuner deploy-lane truth and is upd
 - deploy lane installs the payload directly to `/data/plugins/user_interface/radio_scale_peppy`, runs `npm install`, executes the payload install script, and validates the renderer service/runtime path
 - rollback lane archives the active tuner runtime and removes the active renderer service cleanly
 - both deploy and rollback are now validated on the target Pi through the governed lock-aware workflow lane
+- tuner is now enabled for autonomous delivery dispatch via the shared control plane
 
 ## Current gaps
 - the currently normalized deploy lane covers the overlay and resident renderer service only
@@ -57,9 +60,7 @@ Status note: this v2 file remains the current tuner deploy-lane truth and is upd
 - first-show pointer sweep after boot remains unresolved
 - exit white flashes remain unresolved
 - pointer flicker/jitter is not fully solved
-- autonomous delivery support for tuner is still an explicit follow-up decision and is not promoted automatically by this update
 
 ## Repo-normalized next action
-1. decide whether tuner should now enter the autonomous delivery matrix after successful manual Pi validation
-2. import or normalize the separate `radio_scale_source` artifact if the governed component must again ship both overlay and source as one deploy lane
-3. normalize the next component onto the same repo-driven deploy/rollback model after bridge and tuner
+1. normalize the separate `radio_scale_source` artifact if the governed component must again ship both overlay and source as one deploy lane
+2. normalize the next component onto the same repo-driven deploy/rollback model after bridge and tuner

--- a/journals/scale-radio-tuner/stream_v2.md
+++ b/journals/scale-radio-tuner/stream_v2.md
@@ -15,3 +15,4 @@ Status note: this v2 file supersedes `stream_v1.md` as the current tuner stream 
 - 2026-04-15: Added non-interactive privileged execution support for tuner deploy/rollback through `PI_SUDO_PASSWORD` on the runner.
 - 2026-04-15: Manual tuner deploy succeeded on the target Pi.
 - 2026-04-15: Manual tuner rollback succeeded on the target Pi.
+- 2026-04-15: Tuner was promoted into the autonomous delivery matrix with `dev/tuner` and payload `current` as the governed defaults.

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
@@ -1,6 +1,6 @@
 # DECISION LOG — system_integration_normalization
 
-Status note: this v9 file supersedes the earlier v8 truthfulness addendum as the current SI/N decision addendum.
+Status note: this v9 file remains the current SI/N decision addendum and is updated here after tuner autonomy promotion.
 
 ## Decision Entries
 
@@ -112,5 +112,14 @@ Status note: this v9 file supersedes the earlier v8 truthfulness addendum as the
 - What it explicitly does NOT affect: payload pointer names such as `current_dev` and `current`, or the requirement to keep journals and release handoff fields up to date.
 - Follow-up needed: add tags conservatively only when a baseline is actually accepted or locked as rollback truth.
 
+### DEC-system_integration_normalization-25
+- Status: locked
+- Decision: tuner is promoted into the autonomous delivery support matrix with governed defaults `git_ref=dev/tuner`, `payload=current`, `deploy_workflow=component-test-deploy-v10.yml`, and `rollback_workflow=component-test-rollback-v10.yml`.
+- Date context: tuner autonomy promotion phase
+- Why this was chosen: tuner deploy and rollback are now validated on the target Pi, and `dev/tuner` is aligned with `main`, so the support matrix can safely dispatch the same governed lane autonomously.
+- What it affects: autonomous delivery dispatch, issue/PR-driven tuner auto-deploy routing, and SI support-matrix truth.
+- What it explicitly does NOT affect: the still-open need to normalize the separate `radio_scale_source` artifact as part of the governed tuner component contract.
+- Follow-up needed: normalize the remaining source-artifact gap without disabling the validated overlay/runtime/service lane.
+
 ## Superseded Decisions
-- The earlier v8 truthfulness addendum remains historical; this v9 file is the current release-tagging addendum.
+- The earlier v8 truthfulness addendum remains historical; this v9 file is the current release-tagging addendum plus tuner autonomy promotion update.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
@@ -1,6 +1,6 @@
 # COMPONENT STATUS — system_integration_normalization
 
-Status note: this v8 file remains the current SI/N status addendum and is updated here after successful tuner target-Pi validation.
+Status note: this v8 file remains the current SI/N status addendum and is updated here after successful tuner target-Pi validation and autonomy promotion.
 
 ## 1. Scope
 - component name: system_integration_normalization
@@ -21,7 +21,8 @@ Status note: this v8 file remains the current SI/N status addendum and is update
   - a protected-main truth maintenance operating model exists for safe handling of connector mutation limits
   - a target deploy/test exclusivity contract and lock-aware workflow family exist on `main`
   - bridge deploy and rollback are validated on the target Pi
-  - tuner deploy and rollback are now also validated on the target Pi through the manual lock-aware workflow lane
+  - tuner deploy and rollback are validated on the target Pi through the manual lock-aware workflow lane
+  - bridge and tuner are both enabled in the autonomous delivery support matrix
 - what partially works:
   - autonomous delivery is still support-matrix limited and not yet broad across all active components
   - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts may still be required in some cases
@@ -91,7 +92,6 @@ Status note: this v8 file remains the current SI/N status addendum and is update
 - impact: deploy/test/rollback workflows must respect target-slot state such as `free`, `deploying`, `test_open`, `rollback_running`, and `blocked`.
 
 ## 5. Open Decisions
-- when tuner should enter the autonomous delivery support matrix after its now-successful manual Pi validation
 - when additional components beyond bridge and tuner become delivery-capable in the autonomous support matrix
 - whether the repository should later move to private visibility if the cost/risk tradeoff changes
 - whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
@@ -100,11 +100,11 @@ Status note: this v8 file remains the current SI/N status addendum and is update
 - current validated deploy/rollback reference components:
   - Bridge
   - Tuner overlay/runtime/service lane
-- delivery support matrix on `main` remains conservative until tuner is explicitly promoted by decision
+- bridge and tuner are enabled in the autonomous delivery support matrix on `main`
 - owner remains the final onsite acceptance gate before stable truth is merged to `main`
 - tuner still has one explicit contract gap: the separate `radio_scale_source` artifact is not yet normalized inside the new deploy lane
 
 ## 7. Next Recommended Steps
-1. decide whether tuner should now enter the autonomous delivery matrix
-2. normalize the separate `radio_scale_source` artifact if tuner must again ship both overlay and source as one governed lane
-3. normalize the next component wrapper contract after bridge and tuner
+1. normalize the separate `radio_scale_source` artifact if tuner must again ship both overlay and source as one governed lane
+2. normalize the next component wrapper contract after bridge and tuner
+3. standardize immutable payload naming and governed pointer resolution across deployable components

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -41,3 +41,9 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - added non-interactive privileged execution support for tuner through `PI_SUDO_PASSWORD`
 - tuner deploy and tuner rollback both completed successfully on the target Pi
 - purpose: establish tuner as the second validated manual deploy/rollback lane while keeping autonomous promotion as a separate explicit decision
+
+### 2026-04-15 / main / Tuner autonomy promotion
+- tuner was promoted into the autonomous delivery support matrix
+- matrix defaults were fixed to `dev/tuner` plus payload `current`
+- bridge matrix defaults were refreshed to the currently validated v9 workflow pair
+- purpose: keep execution moving forward without a manual-only holding pattern once the validated runtime lane already exists

--- a/tools/governance/autonomous_delivery_matrix_v3.json
+++ b/tools/governance/autonomous_delivery_matrix_v3.json
@@ -4,12 +4,15 @@
       "auto_delivery_supported": true,
       "default_git_ref": "dev/bridge",
       "default_payload": "current_dev",
-      "deploy_workflow": "component-test-deploy-v8.yml",
-      "rollback_workflow": "component-test-rollback-v8.yml"
+      "deploy_workflow": "component-test-deploy-v9.yml",
+      "rollback_workflow": "component-test-rollback-v9.yml"
     },
     "tuner": {
-      "auto_delivery_supported": false,
-      "reason": "deploy contract not yet normalized"
+      "auto_delivery_supported": true,
+      "default_git_ref": "dev/tuner",
+      "default_payload": "current",
+      "deploy_workflow": "component-test-deploy-v10.yml",
+      "rollback_workflow": "component-test-rollback-v10.yml"
     },
     "starter": {
       "auto_delivery_supported": false,


### PR DESCRIPTION
This moves tuner forward into the same governed autonomy loop already used for bridge.

Included
- `tools/governance/autonomous_delivery_matrix_v3.json`
- `journals/scale-radio-tuner/current_state_v2.md`
- `journals/scale-radio-tuner/stream_v2.md`
- `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
- `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
- `journals/system-integration-normalization/stream_v6.md`

What changes
- tuner is promoted to `auto_delivery_supported: true`
- governed tuner defaults are:
  - `git_ref: dev/tuner`
  - `payload: current`
  - `deploy_workflow: component-test-deploy-v10.yml`
  - `rollback_workflow: component-test-rollback-v10.yml`
- bridge matrix defaults are refreshed to the currently validated v9 workflow pair
- repo truth is updated to reflect that tuner is no longer held in a manual-only state

Why now
- tuner deploy and rollback are already validated on the target Pi
- `dev/tuner` is aligned with `main`
- holding tuner back would only add unnecessary manual administration without adding safety

Still explicitly open
- the separate `radio_scale_source` artifact remains a normalization gap and is not being hidden by this promotion
