### PR TITLE
Add URI-based ChatGPT intake prompt contract for governed Git handoff

### DIFF
--- a/contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md
+++ b/contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md
@@ -67,6 +67,28 @@ decision_output_v1:
     - update_labels_and_state
 ```
 
+
+## Owner-to-agent input contract (no repeated copy/paste)
+For external ChatGPT outputs, owner input to SI/agent should be a URI-based governed intake request, not repeated raw-text copy/paste.
+
+Required owner input fields:
+- `source_proposal_uri`
+- `proposal_revision`
+- `demand_type`
+- `components`
+- `decision_need`
+- `decision_options` + `recommended_option`
+
+Reference prompt and strict YAML format:
+- `docs/agents/chatgpt_governed_intake_prompt_v1.md`
+
+Agent execution expectation after receiving this input:
+1. populate/update governed intake fields
+2. produce `decision_output_v1`
+3. commit on dedicated branch (`si/<topic>` for SI/governance scope)
+4. push branch and open PR to `main`
+5. report only final owner approval action (or exact blocker)
+
 ## Project-view readiness rule
 The project `Scale Radio Governance & Delivery` must provide owner-facing views that separate:
 - decisions waiting for owner approval

--- a/docs/agents/chatgpt_governed_intake_prompt_v1.md
+++ b/docs/agents/chatgpt_governed_intake_prompt_v1.md
@@ -1,0 +1,55 @@
+# ChatGPT governed intake prompt v1
+
+## Purpose
+This document gives the owner a no-copy-paste chat prompt so an agent can take proposal content from a URI/file reference and do the Git/governance lifting.
+
+## Owner quick prompt (minimal)
+Use this exact prompt in chat when you want the agent to run intake and Git steps:
+
+```text
+Governed intake request.
+Source proposal location: <URI or repo path>
+Proposal revision/digest: <commit SHA, file hash, or dated version>
+Demand type: <ui_ux|component_runtime|cross_component|system_integration>
+Impacted components: <comma-separated component suffixes>
+Decision needed from owner: <single sentence>
+Options: <opt-a>; <opt-b>; <opt-c>
+Recommended option: <opt-a|opt-b|opt-c>
+Do the full governance flow: create/update intake issue fields, prepare decision_output_v1, update required governance/journal docs, commit on si/<topic>, push branch, open PR to main, and report only final approval action for owner.
+```
+
+## Owner prompt (strict form)
+Use this when you want deterministic parsing and less back-and-forth:
+
+```yaml
+governed_intake_v1:
+  source_proposal_uri: "<URI or repo path>"
+  proposal_revision: "<immutable revision/hash>"
+  demand_type: "<ui_ux|component_runtime|cross_component|system_integration>"
+  impact: "<component-only|cross-component|system-wide>"
+  components: ["<suffix-1>", "<suffix-2>"]
+  decision_need: "<single-sentence decision>"
+  decision_options:
+    - id: "opt-a"
+      text: "<option a>"
+    - id: "opt-b"
+      text: "<option b>"
+    - id: "opt-c"
+      text: "<option c>"
+  recommended_option: "opt-a"
+  execution_request:
+    branch_topic: "si/<topic>"
+    require_pr_to_main: true
+    report_mode: "owner-approval-only"
+```
+
+## Expected agent output
+The agent should return:
+1. intake artifact path(s) or issue update fields
+2. `decision_output_v1` block
+3. branch + commit + PR URL
+4. one explicit owner action: approve/merge PR (or exact blocker)
+
+## Notes
+- `source_proposal_uri` can be a GitHub file URL, gist URL, issue comment URL, or an existing repo path.
+- If the proposal exists only in another chat, put it into a file once (gist/repo file) and reference the URI; after that no repeated copy/paste is needed.

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -80,13 +80,14 @@ The system-integration stream operates as the control-plane function set for the
 18. `contracts/repo/governance_unification_delivery_plan_v1.md`
 19. `docs/agents/agent_git_bootstrap_v1.md`
 20. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
-21. `tools/governance/scale_radio_governance_delivery_views_v1.md`
-22. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-23. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-24. `journals/system-integration-normalization/stream_v6.md`
-25. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-26. `journals/scale-radio-bridge/current_state_v1.md`
-27. `journals/scale-radio-tuner/current_state_v2.md`
+21. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
+22. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+23. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+24. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+25. `journals/system-integration-normalization/stream_v6.md`
+26. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+27. `journals/scale-radio-bridge/current_state_v1.md`
+28. `journals/scale-radio-tuner/current_state_v2.md`
 
 ## Locked operating rules
 - `main` is the protected truth branch and final owner acceptance gate
@@ -173,7 +174,8 @@ Use this when an external GPT chat produced a `.md` proposal:
 2. ensure labels normalize to the correct specialist route (`agent:ux` or the relevant `agent:<component>`) and SI escalation labels when impact is cross-component/system-wide
 3. ensure issue contains owner decision packet inputs (options, recommendation, downstream governance files, specialist routing map)
 4. keep owner output in `decision_output_v1` block format so routing can trigger deterministically
-5. if project-view API access is unavailable in the current lane, keep `tools/governance/scale_radio_governance_delivery_views_v1.md` as canonical manual apply blueprint and log the blocker in SI stream
+5. when owner provides external ChatGPT proposal, require URI-based intake fields from `docs/agents/chatgpt_governed_intake_prompt_v1.md` (avoid repeated manual copy/paste)
+6. if project-view API access is unavailable in the current lane, keep `tools/governance/scale_radio_governance_delivery_views_v1.md` as canonical manual apply blueprint and log the blocker in SI stream
 
 ## Current practical priorities
 1. keep the governance and issue control-plane working

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -136,3 +136,9 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - matrix defaults were fixed to `dev/tuner` plus payload `current`
 - bridge matrix defaults were refreshed to the currently validated v9 workflow pair
 - purpose: keep execution moving forward without a manual-only holding pattern once the validated runtime lane already exists
+
+### 2026-04-15 / si/chatgpt-intake-prompt / URI-based owner prompt for governed intake
+- added `docs/agents/chatgpt_governed_intake_prompt_v1.md` with minimal and strict templates so owner can provide one structured input and avoid repeated copy/paste from external chats
+- updated Stage-B autonomy standard to require URI-based intake fields and explicit agent execution expectations through PR-ready handoff
+- updated SI onboarding read order/checklist to include the new prompt contract for external ChatGPT proposal ingestion
+- purpose: make proposal handoff deterministic so agents can take over Git/governance lifting and leave owner with approval-only action


### PR DESCRIPTION
## Summary
- add `docs/agents/chatgpt_governed_intake_prompt_v1.md` with minimal and strict prompt templates so owner can hand off external proposals by URI/revision
- add explicit owner-to-agent URI input contract in `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
- update SI onboarding read order + Stage-B checklist to require URI-based intake fields and avoid repeated copy/paste
- record this governance update in SI stream truth

## Validation
- `bash tools/governance/agent_git_bootstrap_v1.sh`
- `rg -n "Owner-to-agent input contract|chatgpt_governed_intake_prompt_v1|URI-based" contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md docs/agents/system_integration_recovery_onboarding_v7.md journals/system-integration-normalization/stream_v6.md docs/agents/chatgpt_governed_intake_prompt_v1.md`
- `git diff --stat`