### PR TITLE
Make container startup non-blocking and document branch-link 404 behaviour

### DIFF
--- a/docs/agents/codex_cloud_environment_setup_v1.md
+++ b/docs/agents/codex_cloud_environment_setup_v1.md
@@ -1,0 +1,59 @@
+# CODEX CLOUD ENVIRONMENT SETUP V1
+
+## Purpose
+Provide a single copy/paste setup checklist for owners configuring Codex cloud environments for this repository.
+
+## 1) Base environment values
+Set these environment variables in the Codex cloud environment:
+
+```text
+GH_TOKEN=<PAT-or-app-token>
+GITHUB_TOKEN=<same-as-GH_TOKEN>
+CANONICAL_REMOTE_NAME=git
+CANONICAL_REMOTE_URL=https://github.com/SH99999/mediastreamer.git
+RUN_NPM_INSTALL=false
+ALLOW_CLONE_IF_MISSING=false
+RUN_GOVERNANCE_DIAGNOSTICS=false
+NPM_TIMEOUT_SECONDS=180
+```
+
+## 2) Startup script mode
+Recommended: keep Codex cloud on **Auto setup script**.
+
+If custom startup is required, use only:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace/mediastreamer || exit 0
+bash tools/governance/container_startup_setup_v1.sh
+```
+
+Do not add global `npm install` loops in startup.
+Do not run bootstrap/auth checks in startup unless debugging (`RUN_GOVERNANCE_DIAGNOSTICS=true`).
+
+## 3) Remote compatibility rule
+Agents use remote `git` as canonical. Keep `origin` aligned as compatibility alias.
+This is handled automatically by `tools/governance/container_startup_setup_v1.sh`.
+
+## 4) Session verification
+After environment starts, run:
+
+```bash
+bash tools/governance/agent_git_bootstrap_v1.sh
+bash tools/governance/setup_auth_check_v1.sh
+```
+
+Pass criteria:
+- `remote(git): ok`
+- `push auth: ok`
+- `Auth check: result=ok`
+
+## 5) If push is still blocked
+- verify `GH_TOKEN` and `GITHUB_TOKEN` are visible in runtime session env
+- verify token has repo write + pull request write permissions
+- keep branch discipline: `dev/<component>` or `si/<topic>` and PR to `main`
+
+## 6) Why a doc link can show 404
+- If a file exists only on an unmerged branch, opening the `main` URL will show 404.
+- Use the branch selector in GitHub UI or open the file from the PR "Files changed" tab.

--- a/docs/agents/container_startup_setup_v1.md
+++ b/docs/agents/container_startup_setup_v1.md
@@ -1,0 +1,53 @@
+# CONTAINER STARTUP SETUP V1
+
+## Recommended Codex cloud configuration (owner-facing)
+Use **Auto setup script** in Codex cloud unless you have a proven need for custom startup logic.
+
+If you use a custom setup script, keep it minimal and non-blocking:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd /workspace/mediastreamer || exit 0
+bash tools/governance/container_startup_setup_v1.sh
+```
+
+## Environment variables to set in the environment UI
+Required for push-capable agents:
+- `GH_TOKEN=<your PAT or app token>`
+- `GITHUB_TOKEN=<same value as GH_TOKEN>`
+
+Governance defaults:
+- `CANONICAL_REMOTE_NAME=git`
+- `CANONICAL_REMOTE_URL=https://github.com/SH99999/mediastreamer.git`
+
+Optional safety defaults:
+- `RUN_NPM_INSTALL=false` (recommended)
+- `ALLOW_CLONE_IF_MISSING=false` (recommended)
+- `RUN_GOVERNANCE_DIAGNOSTICS=false` (recommended for cloud startup stability)
+- `NPM_TIMEOUT_SECONDS=180`
+
+## What `tools/governance/container_startup_setup_v1.sh` does
+1. normalizes token env (`GH_TOKEN` / `GITHUB_TOKEN`)
+2. verifies repo presence (does **not** clone by default)
+3. configures both remotes to same canonical URL:
+   - `git` (canonical)
+   - `origin` (compatibility)
+4. optional bounded npm install only when `RUN_NPM_INSTALL=true`
+5. optionally runs governance diagnostics only when `RUN_GOVERNANCE_DIAGNOSTICS=true`:
+   - `tools/governance/agent_git_bootstrap_v1.sh`
+   - `tools/governance/setup_auth_check_v1.sh`
+
+## Why this avoids startup hangs
+- no clone unless explicitly allowed (`ALLOW_CLONE_IF_MISSING=true`)
+- no npm install unless explicitly enabled (`RUN_NPM_INSTALL=true`)
+- no diagnostics during startup unless explicitly enabled (`RUN_GOVERNANCE_DIAGNOSTICS=true`)
+- diagnostics are non-fatal and designed for clear owner-action output
+
+## Post-start check (run once in session shell)
+```bash
+bash tools/governance/agent_git_bootstrap_v1.sh
+bash tools/governance/setup_auth_check_v1.sh
+```
+
+Expected: `push auth: ok` and `Auth check: result=ok`.

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -142,3 +142,47 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - updated Stage-B autonomy standard to require URI-based intake fields and explicit agent execution expectations through PR-ready handoff
 - updated SI onboarding read order/checklist to include the new prompt contract for external ChatGPT proposal ingestion
 - purpose: make proposal handoff deterministic so agents can take over Git/governance lifting and leave owner with approval-only action
+
+### 2026-04-15 / si/chat-delivery-instructions / explicit delivered-to-git status contract
+- added `docs/agents/chat_to_git_delivery_process_v1.md` with exact ordered execution steps (bootstrap, branching, mutation, validation, push, PR) and mandatory final status blocks
+- updated `docs/agents/chatgpt_governed_intake_prompt_v1.md` to require explicit `Delivered to Git: YES/NO` reporting with branch/commit/PR or blocker+owner-action
+- updated SI governance index and SI onboarding read chains to include the new chat-to-git process document
+- purpose: remove ambiguity for external chats and force one clear owner-facing statement about whether delivery reached Git or is blocked
+
+### 2026-04-15 / si/container-startup-setup-v1 / container startup setup normalization
+- added `tools/governance/container_startup_setup_v1.sh` to provide deterministic runtime initialization for cloud agents
+- script now aligns both remotes (`git` canonical + `origin` compatibility), runs bounded npm dependency installs only on payload paths with `package.json`, and executes bootstrap/auth diagnostics
+- added `docs/agents/container_startup_setup_v1.md` with one-command usage and environment variable contract
+- updated SI onboarding and SI governance index read chains to include the new container startup setup document
+- purpose: avoid startup stalls in generic setup phases and reduce repeated owner troubleshooting for runtime auth/remote drift
+
+### 2026-04-15 / si/container-startup-fix / cloud startup non-blocking and auth probe hardening
+- updated `tools/governance/container_startup_setup_v1.sh` to default `RUN_NPM_INSTALL=false` so startup does not hang on dependency installation; bounded npm install remains opt-in via env flag
+- added `tools/governance/setup_auth_check_v1.sh` and integrated token-aware dry-run probing so runtime can verify whether env token auth is actually usable for push
+- updated bootstrap logic to retry push auth probe with authenticated HTTPS URL when `GH_TOKEN`/`GITHUB_TOKEN` exists but credential helpers are unavailable
+- updated container startup documentation with explicit Codex cloud behavior notes (setup-only token visibility vs runtime availability) and startup recommendations
+- purpose: make cloud runtime startup deterministic and prevent repeated false-negative "push auth blocked" loops caused by setup/runtime auth mismatch
+
+### 2026-04-15 / si/container-startup-fix / codex-cloud environment setup clarification
+- updated startup script to skip clone unless `ALLOW_CLONE_IF_MISSING=true`, reducing risk of blocking startup when repo is not yet mounted
+- published explicit owner-facing Codex cloud setup checklist in `docs/agents/codex_cloud_environment_setup_v1.md` with exact env vars and minimal custom startup wrapper
+- updated container startup documentation and onboarding/index read chains to point to the new cloud setup checklist
+- purpose: provide one clear configuration path (auto setup preferred, minimal custom wrapper optional) so agents start reliably without environment-level trial and error
+
+### 2026-04-15 / si/onboarding-prompts-all-streams / unified stream onboarding prompts
+- added `docs/agents/onboarding_prompts_all_streams_v1.md` with exact copy/paste onboarding prompts for all active stream lanes (SI, GUI/UI, bridge, tuner, fun-line, starter, autoswitch, hardware)
+- included a dedicated GUI/UI onboarding prompt and shared Delivered-to-Git completion contract for deterministic owner-facing status
+- updated SI governance index and SI onboarding read order to include the new all-stream prompt catalog
+- purpose: provide one canonical prompt source so owner can spin up any stream agent without retyping lane-specific governance constraints
+
+### 2026-04-15 / si/onboarding-prompts-all-streams / connector-blocked fallback manual
+- added `docs/agents/fallback_connector_blocked_manual_v1.md` with exact fallback sequence for connector/write failures (issue create blocked, push blocked, PR create blocked)
+- codified deterministic packaging of missing GitHub mutations into repo artifacts plus one-action owner handoff in `Delivered to Git: NO` format
+- updated SI governance index and onboarding read order to include the fallback manual in canonical agent startup docs
+- purpose: keep delivery truthful and operational when ChatGPT/Codex lanes cannot mutate GitHub directly due connector limitations
+
+### 2026-04-15 / si/cloud-startup-quickfix / startup diagnostics decoupled from container boot
+- updated `tools/governance/container_startup_setup_v1.sh` to skip governance diagnostics by default (`RUN_GOVERNANCE_DIAGNOSTICS=false`) so container startup cannot stall on bootstrap/auth checks
+- updated cloud setup docs to include the new env flag and explicit post-start verification flow (`agent_git_bootstrap_v1.sh` + `setup_auth_check_v1.sh`)
+- documented why branch-only docs can show GitHub 404 when opened via `main` URLs before merge, with guidance to use PR branch/files-changed view
+- purpose: keep Codex cloud startup deterministic while preserving governance diagnostics as explicit, operator-triggered checks after boot

--- a/tools/governance/container_startup_setup_v1.sh
+++ b/tools/governance/container_startup_setup_v1.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-/workspace/mediastreamer}"
+CANONICAL_REMOTE_URL="${CANONICAL_REMOTE_URL:-https://github.com/SH99999/mediastreamer.git}"
+CANONICAL_REMOTE_NAME="${CANONICAL_REMOTE_NAME:-git}"
+COMPAT_REMOTE_NAME="${COMPAT_REMOTE_NAME:-origin}"
+NPM_TIMEOUT_SECONDS="${NPM_TIMEOUT_SECONDS:-180}"
+RUN_NPM_INSTALL="${RUN_NPM_INSTALL:-false}"
+ALLOW_CLONE_IF_MISSING="${ALLOW_CLONE_IF_MISSING:-false}"
+RUN_GOVERNANCE_DIAGNOSTICS="${RUN_GOVERNANCE_DIAGNOSTICS:-false}"
+
+log() {
+  printf '[container-setup] %s\n' "$1"
+}
+
+ensure_repo() {
+  if [[ -d "${REPO_DIR}/.git" ]]; then
+    return 0
+  fi
+
+  if [[ "${ALLOW_CLONE_IF_MISSING}" != "true" ]]; then
+    log "skip clone (repo missing and ALLOW_CLONE_IF_MISSING=false)"
+    return 1
+  fi
+
+  mkdir -p "$(dirname "${REPO_DIR}")"
+  log "clone repo into ${REPO_DIR}"
+  git clone "${CANONICAL_REMOTE_URL}" "${REPO_DIR}"
+  return 0
+}
+configure_remotes() {
+  cd "${REPO_DIR}"
+
+  git remote add "${CANONICAL_REMOTE_NAME}" "${CANONICAL_REMOTE_URL}" 2>/dev/null || true
+  git remote set-url "${CANONICAL_REMOTE_NAME}" "${CANONICAL_REMOTE_URL}"
+
+  git remote add "${COMPAT_REMOTE_NAME}" "${CANONICAL_REMOTE_URL}" 2>/dev/null || true
+  git remote set-url "${COMPAT_REMOTE_NAME}" "${CANONICAL_REMOTE_URL}"
+
+  log "remotes configured (${CANONICAL_REMOTE_NAME} + ${COMPAT_REMOTE_NAME})"
+}
+
+ensure_auth_env() {
+  if [[ -z "${GH_TOKEN:-}" && -z "${GITHUB_TOKEN:-}" ]]; then
+    log "WARN: GH_TOKEN/GITHUB_TOKEN missing (push auth may be blocked)"
+    return 0
+  fi
+
+  export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  export GITHUB_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+}
+
+npm_install_safe() {
+  local path="$1"
+
+  if [[ ! -f "${path}/package.json" ]]; then
+    log "skip npm (${path} has no package.json)"
+    return 0
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    log "skip npm (${path} npm is unavailable in runtime)"
+    return 0
+  fi
+
+  log "npm install in ${path}"
+  if [[ -f "${path}/package-lock.json" ]]; then
+    (cd "${path}" && timeout "${NPM_TIMEOUT_SECONDS}" npm ci --omit=dev --no-audit --no-fund) || log "WARN: npm ci failed in ${path}"
+  else
+    (cd "${path}" && timeout "${NPM_TIMEOUT_SECONDS}" npm install --omit=dev --no-audit --no-fund) || log "WARN: npm install failed in ${path}"
+  fi
+}
+
+run_governance_checks() {
+  cd "${REPO_DIR}"
+
+  if [[ "${RUN_GOVERNANCE_DIAGNOSTICS}" != "true" ]]; then
+    log "skip governance diagnostics (RUN_GOVERNANCE_DIAGNOSTICS=false)"
+    return 0
+  fi
+
+  if [[ -f tools/governance/agent_git_bootstrap_v1.sh ]]; then
+    bash tools/governance/agent_git_bootstrap_v1.sh || true
+  fi
+
+  if [[ -f tools/governance/setup_auth_check_v1.sh ]]; then
+    bash tools/governance/setup_auth_check_v1.sh || true
+  fi
+}
+
+main() {
+  log "start"
+  ensure_auth_env
+  if ensure_repo; then
+    configure_remotes
+  else
+    log "skip remote/governance checks (repo is unavailable in startup phase)"
+    log "done"
+    return 0
+  fi
+
+  if [[ "${RUN_NPM_INSTALL}" == "true" ]]; then
+    cd "${REPO_DIR}"
+    npm_install_safe "components/scale-radio-tuner/payload/current"
+    npm_install_safe "components/scale-radio-fun-line/payload/current"
+    npm_install_safe "components/scale-radio-bridge/payload/022c2_stable"
+  else
+    log "skip npm install (RUN_NPM_INSTALL=false). Use platform auto setup or set RUN_NPM_INSTALL=true."
+  fi
+
+  run_governance_checks
+  log "done"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `RUN_GOVERNANCE_DIAGNOSTICS` to `container_startup_setup_v1.sh` and default it to `false` so cloud startup does not block on bootstrap/auth checks
- document the new startup defaults and post-start verification in the new agent docs
- document branch-only link 404 behaviour for unmerged files
- record this operational change in SI stream truth

## Validation
- `bash -n tools/governance/container_startup_setup_v1.sh tools/governance/agent_git_bootstrap_v1.sh tools/governance/setup_auth_check_v1.sh`
- `RUN_GOVERNANCE_DIAGNOSTICS=false RUN_NPM_INSTALL=false bash tools/governance/container_startup_setup_v1.sh`
- `rg -n "RUN_GOVERNANCE_DIAGNOSTICS|404|branch-only docs|skip governance diagnostics" docs/agents/container_startup_setup_v1.md docs/agents/codex_cloud_environment_setup_v1.md tools/governance/container_startup_setup_v1.sh journals/system-integration-normalization/stream_v6.md`