### PR TITLE
Add branch-target mode to agent bootstrap to prevent refspec errors

### DIFF
--- a/docs/agents/agent_git_bootstrap_v1.md
+++ b/docs/agents/agent_git_bootstrap_v1.md
@@ -15,6 +15,17 @@ Run:
 bash tools/governance/agent_git_bootstrap_v1.sh
 ```
 
+Optional branch-target mode (recommended when you know the lane up front):
+
+```bash
+bash tools/governance/agent_git_bootstrap_v1.sh dev/bridge
+```
+
+Behavior:
+- if `dev/bridge` exists on remote, it is checked out locally
+- if missing, it is created from `git/main`
+- invalid branch names (not `si/*`, `dev/*`, `integration/*`) are rejected
+
 Optional environment overrides:
 - `CANONICAL_REMOTE_NAME` (default: `git`)
 - `CANONICAL_REMOTE_URL` (default: `https://github.com/SH99999/mediastreamer.git`)
@@ -25,10 +36,11 @@ Optional environment overrides:
 Immediately after bootstrap, the agent must report:
 1. current branch
 2. canonical remote status
-3. base sync status
-4. push-auth status
-5. what the agent can do immediately without owner input
-6. what owner action is required (if any)
+3. branch prep status
+4. base sync status
+5. push-auth status
+6. what the agent can do immediately without owner input
+7. what owner action is required (if any)
 
 Use this concise format:
 
@@ -36,6 +48,7 @@ Use this concise format:
 Bootstrap status:
 - branch: <branch>
 - remote(git): <ok|missing|wrong-url>
+- branch prep: <ok|skipped|blocked>
 - base sync: <ok|skipped|blocked>
 - push auth: <ok|blocked>
 - ready now: <what will be done next>

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -186,3 +186,9 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - updated cloud setup docs to include the new env flag and explicit post-start verification flow (`agent_git_bootstrap_v1.sh` + `setup_auth_check_v1.sh`)
 - documented why branch-only docs can show GitHub 404 when opened via `main` URLs before merge, with guidance to use PR branch/files-changed view
 - purpose: keep Codex cloud startup deterministic while preserving governance diagnostics as explicit, operator-triggered checks after boot
+
+### 2026-04-15 / si/bootstrap-branch-prep / prevent refspec-missing startup failures
+- updated `tools/governance/agent_git_bootstrap_v1.sh` to accept an optional requested branch argument (`si/*`, `dev/*`, `integration/*`) and automatically prepare that branch before push steps
+- branch prep behavior now checks out remote branch when available, otherwise creates requested branch from `git/main`
+- updated `docs/agents/agent_git_bootstrap_v1.md` to document branch-target mode and the new `branch prep` status line in required first reply format
+- purpose: avoid repeated `src refspec ... does not match any` failures when agents start on non-target branches like `work`

--- a/tools/governance/agent_git_bootstrap_v1.sh
+++ b/tools/governance/agent_git_bootstrap_v1.sh
@@ -6,6 +6,7 @@ REMOTE_URL="${CANONICAL_REMOTE_URL:-https://github.com/SH99999/mediastreamer.git
 CANONICAL_OWNER_REPO="${CANONICAL_OWNER_REPO:-SH99999/mediastreamer}"
 BASE_BRANCH="${CANONICAL_BASE_BRANCH:-main}"
 AUTO_SYNC_MAIN="${AUTO_SYNC_MAIN:-true}"
+REQUESTED_BRANCH="${1:-${REQUESTED_BRANCH:-}}"
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "error: not inside a git repository"
@@ -16,6 +17,8 @@ CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
 if [[ -z "${CURRENT_BRANCH}" ]]; then
   CURRENT_BRANCH="(detached-head)"
 fi
+BRANCH_PREP_STATUS="skipped"
+BRANCH_PREP_DETAIL="no requested branch"
 
 normalize_remote_identity() {
   local url="$1"
@@ -47,6 +50,39 @@ if git remote get-url "${REMOTE_NAME}" >/dev/null 2>&1; then
 else
   git remote add "${REMOTE_NAME}" "${REMOTE_URL}"
   REMOTE_STATUS="ok (added)"
+fi
+
+if [[ -n "${REQUESTED_BRANCH}" ]]; then
+  if [[ "${REQUESTED_BRANCH}" =~ ^(si|dev|integration)/ ]]; then
+    if [[ "${CURRENT_BRANCH}" == "${REQUESTED_BRANCH}" ]]; then
+      BRANCH_PREP_STATUS="ok"
+      BRANCH_PREP_DETAIL="already on requested branch"
+    else
+      if git show-ref --verify --quiet "refs/remotes/${REMOTE_NAME}/${REQUESTED_BRANCH}"; then
+        git checkout -B "${REQUESTED_BRANCH}" "${REMOTE_NAME}/${REQUESTED_BRANCH}" >/dev/null 2>&1
+        BRANCH_PREP_STATUS="ok"
+        BRANCH_PREP_DETAIL="checked out ${REQUESTED_BRANCH} from ${REMOTE_NAME}/${REQUESTED_BRANCH}"
+      elif git fetch "${REMOTE_NAME}" "${BASE_BRANCH}" >/dev/null 2>&1 && git show-ref --verify --quiet "refs/remotes/${REMOTE_NAME}/${BASE_BRANCH}"; then
+        git checkout -B "${REQUESTED_BRANCH}" "${REMOTE_NAME}/${BASE_BRANCH}" >/dev/null 2>&1
+        BRANCH_PREP_STATUS="ok"
+        BRANCH_PREP_DETAIL="created ${REQUESTED_BRANCH} from ${REMOTE_NAME}/${BASE_BRANCH}"
+      elif git show-ref --verify --quiet "refs/heads/${REQUESTED_BRANCH}"; then
+        git checkout "${REQUESTED_BRANCH}" >/dev/null 2>&1
+        BRANCH_PREP_STATUS="ok"
+        BRANCH_PREP_DETAIL="checked out existing local branch"
+      else
+        BRANCH_PREP_STATUS="blocked"
+        BRANCH_PREP_DETAIL="could not create or checkout requested branch"
+      fi
+      CURRENT_BRANCH="$(git branch --show-current 2>/dev/null || true)"
+      if [[ -z "${CURRENT_BRANCH}" ]]; then
+        CURRENT_BRANCH="(detached-head)"
+      fi
+    fi
+  else
+    BRANCH_PREP_STATUS="blocked"
+    BRANCH_PREP_DETAIL="requested branch must match si/*, dev/*, or integration/*"
+  fi
 fi
 
 PUSH_AUTH_STATUS="blocked"
@@ -87,6 +123,7 @@ fi
 echo "Bootstrap status:"
 echo "- branch: ${CURRENT_BRANCH}"
 echo "- remote(${REMOTE_NAME}): ${REMOTE_STATUS}"
+echo "- branch prep: ${BRANCH_PREP_STATUS} (${BRANCH_PREP_DETAIL})"
 echo "- base sync: ${BASE_SYNC_STATUS} (${BASE_SYNC_DETAIL})"
 echo "- push auth: ${PUSH_AUTH_STATUS} (${PUSH_AUTH_DETAIL})"
 


### PR DESCRIPTION
## Summary
- add branch-target mode to `agent_git_bootstrap_v1.sh` so agents can request `dev/*`, `si/*`, or `integration/*` directly at startup
- if remote target branch exists, checkout from remote; otherwise create target branch from `git/main`
- add `branch prep` status line to bootstrap output and document it in agent bootstrap docs
- record the operational change in SI stream truth

## Why
This prevents startup failures like `src refspec dev/bridge does not match any` when the runtime starts on `work` and target branch does not exist locally.

## Validation
- `bash -n tools/governance/agent_git_bootstrap_v1.sh`
- `bash tools/governance/agent_git_bootstrap_v1.sh dev/bridge`
- `bash tools/governance/agent_git_bootstrap_v1.sh invalid-branch-name`
- `rg -n "branch prep|branch-target mode|requested branch" tools/governance/agent_git_bootstrap_v1.sh docs/agents/agent_git_bootstrap_v1.md journals/system-integration-normalization/stream_v6.md`