### PR TITLE
Fix bootstrap push auth by using GH_TOKEN-backed credential fallback

### DIFF
--- a/docs/agents/agent_git_bootstrap_v1.md
+++ b/docs/agents/agent_git_bootstrap_v1.md
@@ -25,6 +25,7 @@ Behavior:
 - if `dev/bridge` exists on remote, it is checked out locally
 - if missing, it is created from `git/main`
 - invalid branch names (not `si/*`, `dev/*`, `integration/*`) are rejected
+- if `GH_TOKEN`/`GITHUB_TOKEN` exists and plain push auth fails, bootstrap configures a local repo credential helper for `https://github.com` and re-probes push auth
 
 Optional environment overrides:
 - `CANONICAL_REMOTE_NAME` (default: `git`)

--- a/docs/agents/codex_cloud_environment_setup_v1.md
+++ b/docs/agents/codex_cloud_environment_setup_v1.md
@@ -49,6 +49,8 @@ Pass criteria:
 - `push auth: ok`
 - `Auth check: result=ok`
 
+Note: `agent_git_bootstrap_v1.sh` now attempts a local credential-helper configuration from `GH_TOKEN`/`GITHUB_TOKEN` when plain HTTPS push auth fails, then rechecks push auth.
+
 ## 5) If push is still blocked
 - verify `GH_TOKEN` and `GITHUB_TOKEN` are visible in runtime session env
 - verify token has repo write + pull request write permissions

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -192,3 +192,9 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - branch prep behavior now checks out remote branch when available, otherwise creates requested branch from `git/main`
 - updated `docs/agents/agent_git_bootstrap_v1.md` to document branch-target mode and the new `branch prep` status line in required first reply format
 - purpose: avoid repeated `src refspec ... does not match any` failures when agents start on non-target branches like `work`
+
+### 2026-04-15 / si/bootstrap-push-auth-fallback / token-backed git push probing
+- updated `tools/governance/agent_git_bootstrap_v1.sh` so when `GH_TOKEN`/`GITHUB_TOKEN` exists but plain HTTPS push auth fails, bootstrap configures a local repo credential helper and retries push probing
+- fallback now also tests tokenized HTTPS URL probe and reports explicit detail (`configured credential helper...` vs `token present but push dry-run failed`)
+- updated agent/cloud setup docs to reflect this behavior and reduce false `push auth: blocked` statuses in Codex cloud sessions
+- purpose: let agent lanes with valid env tokens push with standard `git push -u git <branch>` instead of failing on username prompt

--- a/tools/governance/agent_git_bootstrap_v1.sh
+++ b/tools/governance/agent_git_bootstrap_v1.sh
@@ -90,10 +90,31 @@ PUSH_AUTH_DETAIL="auth not available in current runtime"
 PROBE_REF="refs/heads/_bootstrap_auth_probe_$(date +%s)"
 BASE_SYNC_STATUS="skipped"
 BASE_SYNC_DETAIL="disabled or non-target branch"
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
 if git push --dry-run "${REMOTE_NAME}" "HEAD:${PROBE_REF}" >/dev/null 2>&1; then
   PUSH_AUTH_STATUS="ok"
   PUSH_AUTH_DETAIL="push dry-run succeeded"
+elif [[ -n "${TOKEN}" ]]; then
+  REMOTE_ACTUAL_URL="$(git remote get-url "${REMOTE_NAME}")"
+  if [[ "${REMOTE_ACTUAL_URL}" =~ ^https://github.com/ ]]; then
+    git config --local credential.helper \
+      '!f() { test -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" || exit 0; echo username=x-access-token; echo password="${GH_TOKEN:-${GITHUB_TOKEN:-}}"; }; f'
+    if git push --dry-run "${REMOTE_NAME}" "HEAD:${PROBE_REF}" >/dev/null 2>&1; then
+      PUSH_AUTH_STATUS="ok"
+      PUSH_AUTH_DETAIL="configured credential helper from GH_TOKEN/GITHUB_TOKEN"
+    else
+      AUTH_REMOTE_URL="https://x-access-token:${TOKEN}@${REMOTE_ACTUAL_URL#https://}"
+      if git push --dry-run "${AUTH_REMOTE_URL}" "HEAD:${PROBE_REF}" >/dev/null 2>&1; then
+        PUSH_AUTH_STATUS="ok"
+        PUSH_AUTH_DETAIL="env token is usable for authenticated HTTPS push"
+      else
+        PUSH_AUTH_DETAIL="token present but push dry-run failed"
+      fi
+    fi
+  else
+    PUSH_AUTH_DETAIL="token present but remote is not HTTPS github URL"
+  fi
 fi
 
 if [[ "${AUTO_SYNC_MAIN}" == "true" && "${CURRENT_BRANCH}" != "(detached-head)" && "${CURRENT_BRANCH}" != "${BASE_BRANCH}" ]]; then


### PR DESCRIPTION
## Summary
- update `agent_git_bootstrap_v1.sh` to auto-configure local credential helper from `GH_TOKEN`/`GITHUB_TOKEN` if plain HTTPS push auth fails
- keep tokenized HTTPS dry-run fallback and improve push-auth detail reporting
- update agent/cloud docs and SI stream with the new behavior

## Why
Agents were reporting `push auth: blocked` and failing `git push -u git <branch>` even though token env vars were present in Codex cloud.

## Validation
- `bash -n tools/governance/agent_git_bootstrap_v1.sh`
- `GH_TOKEN=<PAT> bash tools/governance/agent_git_bootstrap_v1.sh dev/tuner`
- `rg -n "credential helper|token present|GH_TOKEN|branch prep" tools/governance/agent_git_bootstrap_v1.sh docs/agents/agent_git_bootstrap_v1.md docs/agents/codex_cloud_environment_setup_v1.md journals/system-integration-normalization/stream_v6.md`