### PR TITLE
Add owner single-page operations reference and wire into SI read chains

### DIFF
--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -30,11 +30,12 @@ This file is the current entrypoint for system integration governance, recovery,
 18. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
 19. `docs/agents/agent_git_bootstrap_v1.md`
 20. `docs/agents/system_integration_recovery_onboarding_v7.md`
-21. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-22. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-23. `journals/system-integration-normalization/stream_v6.md`
-24. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-25. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+21. `docs/agents/owner_operational_reference_v1.md`
+22. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+23. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+24. `journals/system-integration-normalization/stream_v6.md`
+25. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+26. `tools/governance/scale_radio_governance_delivery_views_v1.md`
 
 ## Locked operating model
 - the repository remains public until further notice

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -1,0 +1,101 @@
+# OWNER OPERATIONAL REFERENCE V1
+
+## Purpose
+This page is the single owner-facing reference for daily operation, governance checks, onboarding shortcuts, click paths, and readiness decisions.
+
+## Fast answer panel
+### Are we ready to develop?
+Use this YES/NO gate:
+1. `main` is protected and PR-gated.
+2. Agent bootstrap reports:
+   - branch is `dev/<component>` or `si/<topic>`
+   - remote `git` points to `https://github.com/SH99999/mediastreamer.git`
+   - base sync is `ok`
+   - push auth is `ok`
+3. active issue/PR has governance labels.
+4. affected component journal current-state + stream are updated.
+5. deploy/rollback evidence is attached when runtime paths changed.
+
+If any gate is `no`, treat as not ready and run the blocker path.
+
+### Do we still have setup topics?
+Current recurring topics to monitor:
+- runtime token injection drift (`GH_TOKEN`/`GITHUB_TOKEN` not visible in active session)
+- branch discipline drift (agents starting on `work` instead of `dev/*` or `si/*`)
+- connector-lane mismatch (issue create available but PR create blocked, or vice versa)
+
+### Can ChatGPT issue creation be automated?
+Yes. Intake issue creation/normalization/routing is already automatable through repository workflows.
+Use the issue templates and let workflows apply labels and routing automatically.
+If connector write is blocked in a specific chat lane, fallback to PR-packaged intake fields and one-step owner handoff.
+
+### Governance status
+Governance model is operational for controlled branch->PR->main flow.
+The remaining risk is runtime auth/connector availability, not missing governance doctrine.
+
+## Owner daily flow (click-path version)
+1. Open project board `Scale Radio Governance & Delivery`.
+2. Check `Owner Decision Queue` view.
+3. Open top item and read:
+   - decision statement
+   - options + recommended option
+   - blocker or dependency notes
+4. If accepted, approve PR to `main`.
+5. Confirm post-merge checks:
+   - rebase workflow run
+   - decision/governance closeout comments
+6. If blocked, request agent rerun with explicit owner action response.
+
+## Minimal owner command checks (copy/paste)
+```bash
+bash tools/governance/agent_git_bootstrap_v1.sh
+bash tools/governance/setup_auth_check_v1.sh
+```
+Interpretation:
+- `push auth: ok` and `Auth check: result=ok` => agent can deliver branch+PR without owner push help.
+- `blocked` => owner must fix runtime auth injection or perform final push/PR manually.
+
+## When an agent says "Delivered to Git: NO"
+Require this exact triage:
+1. one blocker only
+2. what is completed locally
+3. one owner action only
+4. no claim of pushed PR if push did not happen
+
+## Primary links
+### Governance and operating doctrine
+- `AGENTS.md`
+- `contracts/repo/system_integration_governance_index_v7.md`
+- `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
+- `contracts/repo/deploy_process_standard_v1.md`
+- `contracts/repo/ui_gui_governance_standard_v1.md`
+
+### Owner onboarding and execution
+- `docs/agents/system_integration_recovery_onboarding_v7.md`
+- `docs/agents/agent_git_bootstrap_v1.md`
+- `docs/agents/codex_cloud_environment_setup_v1.md`
+- `docs/agents/container_startup_setup_v1.md`
+- `docs/agents/chat_to_git_delivery_process_v1.md`
+- `docs/agents/fallback_connector_blocked_manual_v1.md`
+
+### Intake and decision automation
+- `.github/ISSUE_TEMPLATE/governed-demand-intake.yml`
+- `.github/ISSUE_TEMPLATE/ui-ux-and-asset-governance.yml`
+- `.github/workflows/issue-intake-normalizer-v2.yml`
+- `.github/workflows/system-integration-escalation.yml`
+- `.github/workflows/open-decision-issues.yml`
+- `.github/workflows/governance-closeout.yml`
+
+### Owner project-view references
+- `tools/governance/scale_radio_governance_delivery_views_v1.md`
+- `tools/governance/scale_radio_governance_delivery_views_table_v1.md`
+- `tools/governance/scale_radio_governance_delivery_views_kanban_v1.md`
+
+## Required owner decision output format
+When giving a decision back to agents, use:
+- decision: `<accept|reject|defer>`
+- scope: `<component(s) or governance topic>`
+- mandatory follow-up: `<what must happen next>`
+- merge authorization: `<yes|no>`
+
+This keeps routing deterministic and minimizes follow-up clicks.

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -1,101 +1,99 @@
-# OWNER OPERATIONAL REFERENCE V1
+# Owner Operational Reference v1
 
 ## Purpose
-This page is the single owner-facing reference for daily operation, governance checks, onboarding shortcuts, click paths, and readiness decisions.
+This is the single owner-facing page for decisions, onboarding links, governance operations, and review workflow.
 
-## Fast answer panel
-### Are we ready to develop?
-Use this YES/NO gate:
+## Decision and review workflow (defined)
+### Where to give improvement feedback
+- **Preferred:** directly on the PR as review comments (inline where possible).
+- **Allowed:** in chat for quick triage or urgent steering.
+
+### Should the PR be closed when improvements are needed?
+- **No (default):** keep PR open, request changes, agent updates same branch/PR.
+- **Yes (exception):** close only if scope is rejected or replaced by a new branch/topic.
+
+### Owner merge decision contract
+Use this short format in chat or PR comment:
+- `decision: accept | changes-requested | reject`
+- `scope: <component/governance topic>`
+- `mandatory follow-up: <required change>`
+- `merge authorization: yes | no`
+
+## Are we ready to develop? (YES/NO gate)
+Answer **YES** only if all are true:
 1. `main` is protected and PR-gated.
-2. Agent bootstrap reports:
-   - branch is `dev/<component>` or `si/<topic>`
-   - remote `git` points to `https://github.com/SH99999/mediastreamer.git`
-   - base sync is `ok`
-   - push auth is `ok`
-3. active issue/PR has governance labels.
-4. affected component journal current-state + stream are updated.
-5. deploy/rollback evidence is attached when runtime paths changed.
+2. Bootstrap reports:
+   - branch = `dev/<component>` or `si/<topic>`
+   - remote `git` = `https://github.com/SH99999/mediastreamer.git`
+   - base sync = `ok`
+   - push auth = `ok`
+3. active issue/PR carries governance routing labels.
+4. affected journals are updated (`current_state` + `stream`).
+5. deploy/rollback evidence exists when runtime/deploy paths changed.
 
-If any gate is `no`, treat as not ready and run the blocker path.
+If one gate fails: not ready -> use blocker handling below.
 
-### Do we still have setup topics?
-Current recurring topics to monitor:
-- runtime token injection drift (`GH_TOKEN`/`GITHUB_TOKEN` not visible in active session)
-- branch discipline drift (agents starting on `work` instead of `dev/*` or `si/*`)
-- connector-lane mismatch (issue create available but PR create blocked, or vice versa)
+## Blocker handling (Delivered-to-Git: NO)
+Require exactly:
+1. one blocker only
+2. what is completed locally
+3. one owner action only
+4. no claim of pushed PR when not pushed
 
-### Can ChatGPT issue creation be automated?
-Yes. Intake issue creation/normalization/routing is already automatable through repository workflows.
-Use the issue templates and let workflows apply labels and routing automatically.
-If connector write is blocked in a specific chat lane, fallback to PR-packaged intake fields and one-step owner handoff.
+## Owner click-path (daily)
+1. Open project board: [Scale Radio Governance & Delivery](https://github.com/users/SH99999/projects/1)
+2. Review queue defined in: [Project view blueprint](../../tools/governance/scale_radio_governance_delivery_views_v1.md)
+3. Open top item and verify decision packet + recommended option.
+4. If accepted, approve/merge PR to `main`.
+5. Confirm post-merge automation:
+   - rebase workflow
+   - governance closeout / decision verification comments
 
-### Governance status
-Governance model is operational for controlled branch->PR->main flow.
-The remaining risk is runtime auth/connector availability, not missing governance doctrine.
+## Can ChatGPT issue creation be automated?
+**Yes.** Intake creation/normalization/routing is workflow-backed.
+- Use the governed issue templates.
+- Workflows normalize labels and route/escalate automatically.
+- If a connector lane cannot create issues, use fallback: package issue fields in PR + one owner action.
 
-## Owner daily flow (click-path version)
-1. Open project board `Scale Radio Governance & Delivery`.
-2. Check `Owner Decision Queue` view.
-3. Open top item and read:
-   - decision statement
-   - options + recommended option
-   - blocker or dependency notes
-4. If accepted, approve PR to `main`.
-5. Confirm post-merge checks:
-   - rebase workflow run
-   - decision/governance closeout comments
-6. If blocked, request agent rerun with explicit owner action response.
-
-## Minimal owner command checks (copy/paste)
+## Minimal owner checks (copy/paste)
 ```bash
 bash tools/governance/agent_git_bootstrap_v1.sh
 bash tools/governance/setup_auth_check_v1.sh
 ```
 Interpretation:
-- `push auth: ok` and `Auth check: result=ok` => agent can deliver branch+PR without owner push help.
-- `blocked` => owner must fix runtime auth injection or perform final push/PR manually.
+- `push auth: ok` and `Auth check: result=ok` => agent can push and open PR.
+- `blocked` => fix runtime auth injection or perform final push manually.
 
-## When an agent says "Delivered to Git: NO"
-Require this exact triage:
-1. one blocker only
-2. what is completed locally
-3. one owner action only
-4. no claim of pushed PR if push did not happen
+## Primary links (clickable)
+### Governance core
+- [AGENTS.md](../../AGENTS.md)
+- [SI governance index v7](../../contracts/repo/system_integration_governance_index_v7.md)
+- [Protected-main operating model](../../contracts/repo/protected_main_truth_maintenance_operating_model_v1.md)
+- [Deploy process standard](../../contracts/repo/deploy_process_standard_v1.md)
+- [UI/GUI governance standard](../../contracts/repo/ui_gui_governance_standard_v1.md)
 
-## Primary links
-### Governance and operating doctrine
-- `AGENTS.md`
-- `contracts/repo/system_integration_governance_index_v7.md`
-- `contracts/repo/protected_main_truth_maintenance_operating_model_v1.md`
-- `contracts/repo/deploy_process_standard_v1.md`
-- `contracts/repo/ui_gui_governance_standard_v1.md`
+### Onboarding and execution
+- [SI recovery onboarding v7](./system_integration_recovery_onboarding_v7.md)
+- [Agent git bootstrap guide](./agent_git_bootstrap_v1.md)
+- [Codex cloud environment setup](./codex_cloud_environment_setup_v1.md)
+- [Container startup setup](./container_startup_setup_v1.md)
+- [Chat-to-Git delivery process](./chat_to_git_delivery_process_v1.md)
+- [Connector-blocked fallback manual](./fallback_connector_blocked_manual_v1.md)
 
-### Owner onboarding and execution
-- `docs/agents/system_integration_recovery_onboarding_v7.md`
-- `docs/agents/agent_git_bootstrap_v1.md`
-- `docs/agents/codex_cloud_environment_setup_v1.md`
-- `docs/agents/container_startup_setup_v1.md`
-- `docs/agents/chat_to_git_delivery_process_v1.md`
-- `docs/agents/fallback_connector_blocked_manual_v1.md`
+### Intake and governance automation
+- [Governed demand intake template](../../.github/ISSUE_TEMPLATE/governed-demand-intake.yml)
+- [UI/UX governance intake template](../../.github/ISSUE_TEMPLATE/ui-ux-and-asset-governance.yml)
+- [Issue intake normalizer v2 workflow](../../.github/workflows/issue-intake-normalizer-v2.yml)
+- [System integration escalation workflow](../../.github/workflows/system-integration-escalation.yml)
+- [Open decision issues workflow](../../.github/workflows/open-decision-issues.yml)
+- [Governance closeout workflow](../../.github/workflows/governance-closeout.yml)
 
-### Intake and decision automation
-- `.github/ISSUE_TEMPLATE/governed-demand-intake.yml`
-- `.github/ISSUE_TEMPLATE/ui-ux-and-asset-governance.yml`
-- `.github/workflows/issue-intake-normalizer-v2.yml`
-- `.github/workflows/system-integration-escalation.yml`
-- `.github/workflows/open-decision-issues.yml`
-- `.github/workflows/governance-closeout.yml`
+### Governance panel/view references
+- [Project views blueprint](../../tools/governance/scale_radio_governance_delivery_views_v1.md)
+- [Project views table rendering](../../tools/governance/scale_radio_governance_delivery_views_table_v1.md)
+- [Project views kanban rendering](../../tools/governance/scale_radio_governance_delivery_views_kanban_v1.md)
 
-### Owner project-view references
-- `tools/governance/scale_radio_governance_delivery_views_v1.md`
-- `tools/governance/scale_radio_governance_delivery_views_table_v1.md`
-- `tools/governance/scale_radio_governance_delivery_views_kanban_v1.md`
-
-## Required owner decision output format
-When giving a decision back to agents, use:
-- decision: `<accept|reject|defer>`
-- scope: `<component(s) or governance topic>`
-- mandatory follow-up: `<what must happen next>`
-- merge authorization: `<yes|no>`
-
-This keeps routing deterministic and minimizes follow-up clicks.
+## Current recurring setup topics to monitor
+- runtime token injection drift (`GH_TOKEN` / `GITHUB_TOKEN` not visible in active runtime session)
+- branch discipline drift (agent starts on `work` instead of `dev/*` or `si/*`)
+- connector-lane mismatch (issue create available but PR create blocked, or inverse)

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -82,12 +82,13 @@ The system-integration stream operates as the control-plane function set for the
 20. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
 21. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
 22. `tools/governance/scale_radio_governance_delivery_views_v1.md`
-23. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-24. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-25. `journals/system-integration-normalization/stream_v6.md`
-26. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-27. `journals/scale-radio-bridge/current_state_v1.md`
-28. `journals/scale-radio-tuner/current_state_v2.md`
+23. `docs/agents/owner_operational_reference_v1.md`
+24. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+25. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+26. `journals/system-integration-normalization/stream_v6.md`
+27. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+28. `journals/scale-radio-bridge/current_state_v1.md`
+29. `journals/scale-radio-tuner/current_state_v2.md`
 
 ## Locked operating rules
 - `main` is the protected truth branch and final owner acceptance gate

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -198,3 +198,8 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - fallback now also tests tokenized HTTPS URL probe and reports explicit detail (`configured credential helper...` vs `token present but push dry-run failed`)
 - updated agent/cloud setup docs to reflect this behavior and reduce false `push auth: blocked` statuses in Codex cloud sessions
 - purpose: let agent lanes with valid env tokens push with standard `git push -u git <branch>` instead of failing on username prompt
+
+### 2026-04-15 / si/owner-reference-validation / owner single-page operations reference
+- added `docs/agents/owner_operational_reference_v1.md` as a single owner-facing page with readiness gates, blocker triage, automation status, click-path flow, and direct links to core governance/onboarding/automation docs
+- updated SI governance index and SI onboarding read chains to include the owner operational reference as canonical startup material
+- purpose: give owner one deterministic page to validate setup state, assess readiness-to-dev, and run low-click decision/approval flow

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -203,3 +203,9 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - added `docs/agents/owner_operational_reference_v1.md` as a single owner-facing page with readiness gates, blocker triage, automation status, click-path flow, and direct links to core governance/onboarding/automation docs
 - updated SI governance index and SI onboarding read chains to include the owner operational reference as canonical startup material
 - purpose: give owner one deterministic page to validate setup state, assess readiness-to-dev, and run low-click decision/approval flow
+
+### 2026-04-15 / si/owner-reference-validation / owner page structured and fully clickable
+- refined `docs/agents/owner_operational_reference_v1.md` to include explicit PR feedback/close policy, owner decision contract, and blocker handling rules
+- converted owner-relevant document and workflow lists to markdown links so the page is directly clickable in GitHub
+- added direct project board link (`https://github.com/users/SH99999/projects/1`) and daily owner click-path guidance
+- purpose: ensure owner can review and decide from one page with minimal navigation friction


### PR DESCRIPTION
## Summary
- add `docs/agents/owner_operational_reference_v1.md` as a single owner-facing page with readiness gates, blocker triage, automation status, click-path flow, and direct links to core governance/onboarding/automation docs
- include the owner reference in canonical SI read order in `contracts/repo/system_integration_governance_index_v7.md` and `docs/agents/system_integration_recovery_onboarding_v7.md`
- append SI stream entry documenting this owner-reference consolidation

## Why
Owner requested one deterministic page with all operationally relevant links and quick answers for setup validation, governance status, automatic issue intake handling, and readiness-to-dev decisions.

## Validation
- `rg -n "owner_operational_reference_v1|owner single-page operations reference" contracts/repo/system_integration_governance_index_v7.md docs/agents/system_integration_recovery_onboarding_v7.md journals/system-integration-normalization/stream_v6.md docs/agents/owner_operational_reference_v1.md`
- `sed -n '1,220p' docs/agents/owner_operational_reference_v1.md`
- `git log --oneline -n 1`