### PR TITLE
Add measurable Pi deployment test strategy and component verification guide

### DIFF
--- a/contracts/repo/deployment_test_strategy_standard_v1.md
+++ b/contracts/repo/deployment_test_strategy_standard_v1.md
@@ -1,0 +1,93 @@
+# DEPLOYMENT TEST STRATEGY STANDARD V1
+
+## Purpose
+This standard defines a measurable, repeatable deployment-test strategy for all components on the target Pi.
+
+## Outcome
+After each Pi test run, the repository should have enough structured evidence to:
+- evaluate deploy and rollback quality objectively
+- compare run quality over time
+- generate automated summaries and charts from run outputs
+
+## Test layers
+Every test run should execute and report these layers:
+1. **L0 - pipeline/branch metadata**
+2. **L1 - standard deploy contract checks**
+3. **L2 - component-specific verification checks**
+4. **L3 - rollback verification checks** (when rollback is part of the run)
+
+## Required run metadata
+Each run should record:
+- component
+- branch/ref
+- payload
+- workflow name/run id
+- target host and slot/lock context
+- start/end timestamps (UTC)
+- final status (`pass`|`fail`)
+
+## Measurable success metrics
+At minimum, evaluate these metrics per run:
+- deploy execution duration (seconds)
+- healthcheck duration (seconds)
+- rollback duration (seconds, if executed)
+- required-check pass ratio (`passed_checks/total_checks`)
+- critical-check failures (`0` required for pass)
+- service/process stability checks (all required checks pass)
+
+## Required evidence bundle (per run)
+Store a run bundle under:
+`artifacts/pi-test-results/<component>/<run-id>/`
+
+Required files:
+- `summary.json` (top-level result and timing)
+- `checks.jsonl` (one JSON object per check)
+- `environment.txt` (branch/ref/payload/workflow/target)
+- `service_status.txt` (`systemctl` snapshots for relevant services)
+- `process_snapshot.txt` (`ps`/`pgrep` summary for required processes)
+- `notes.md` (short context for anomalies)
+
+## Standard + component-specific script model
+For each component, use:
+- standard deploy/health/rollback scripts (existing contract)
+- optional component-specific verification script:
+  - `deploy_candidates/verify_pi_postdeploy_v1.sh`
+
+Execution order for deploy runs:
+1. `apply_payload_v1.sh`
+2. `healthcheck_runtime_v1.sh`
+3. `verify_pi_postdeploy_v1.sh` (if present)
+
+Execution order for rollback runs:
+1. `remove_active_v1.sh`
+2. `verify_pi_postdeploy_v1.sh --post-rollback` (if present)
+
+## Check result contract
+Each line in `checks.jsonl` should include:
+- `check_id`
+- `layer` (`L1`/`L2`/`L3`)
+- `severity` (`critical`|`major`|`minor`)
+- `status` (`pass`|`fail`)
+- `value` (numeric/string measurement)
+- `threshold` (if measurable)
+- `message`
+
+## Pass/fail rule
+A run is `pass` only if:
+- all critical checks pass
+- required-check pass ratio is at least `1.0`
+- deploy and healthcheck completed without script error
+- rollback completed without script error when rollback is requested
+
+## Reporting and chart generation
+The run bundles are machine-readable by design.
+A report generator may produce:
+- markdown summary tables
+- trend charts (for example Mermaid charts)
+- per-component pass-rate and duration trend views
+
+## Governance update rule
+If this strategy changes a component acceptance decision:
+- update component current-state + stream
+- update SI status/stream where the strategy materially changes operating truth
+- keep matrix and workflow references aligned in the same change set when possible

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -28,15 +28,16 @@ This file is the current entrypoint for system integration governance, recovery,
 16. `contracts/repo/git_release_tagging_standard_v1.md`
 17. `contracts/repo/governance_unification_delivery_plan_v1.md`
 18. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
-19. `docs/agents/agent_git_bootstrap_v1.md`
-20. `docs/agents/status_prompt_reports_v1.md`
-21. `docs/agents/system_integration_recovery_onboarding_v7.md`
-22. `docs/agents/owner_operational_reference_v1.md`
-23. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-24. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-25. `journals/system-integration-normalization/stream_v6.md`
-26. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-27. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+19. `contracts/repo/deployment_test_strategy_standard_v1.md`
+20. `docs/agents/agent_git_bootstrap_v1.md`
+21. `docs/agents/status_prompt_reports_v1.md`
+22. `docs/agents/system_integration_recovery_onboarding_v7.md`
+23. `docs/agents/owner_operational_reference_v1.md`
+24. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+25. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+26. `journals/system-integration-normalization/stream_v6.md`
+27. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+28. `tools/governance/scale_radio_governance_delivery_views_v1.md`
 
 ## Locked operating model
 - the repository remains public until further notice

--- a/docs/agents/pi_component_test_guide_v1.md
+++ b/docs/agents/pi_component_test_guide_v1.md
@@ -1,0 +1,82 @@
+# PI COMPONENT TEST GUIDE V1
+
+## Purpose
+This guide translates the deployment test strategy into component-level execution checklists.
+
+Primary standard:
+- `contracts/repo/deployment_test_strategy_standard_v1.md`
+
+## Common execution flow (all components)
+1. Prepare branch/ref and payload.
+2. Run deploy workflow/script lane.
+3. Run standard healthcheck.
+4. Run component-specific verification script (`verify_pi_postdeploy_v1.sh`) when present.
+5. Run rollback workflow/script lane when part of the test cycle.
+6. Collect evidence bundle under `artifacts/pi-test-results/<component>/<run-id>/`.
+7. Generate summary report/charts.
+8. Update journals with factual results.
+
+## Component checklists
+
+### bridge (`dev/bridge`)
+Required extra checks:
+- overlay opens from intended entry path
+- expected bridge runtime state appears without ownership conflicts
+- cache DB path exists/reuses as expected (`bridge_cache.sqlite` if in scope)
+
+Recommended `verify_pi_postdeploy_v1.sh` checks:
+- overlay-process check
+- UI path response check
+- bridge cache file check
+
+### tuner (`dev/tuner`)
+Required extra checks:
+- runtime plugin and renderer-service are both healthy
+- source-tile checks only if explicitly in active scope
+
+Recommended `verify_pi_postdeploy_v1.sh` checks:
+- renderer service active
+- runtime files present
+- expected tuner process/service coupling valid
+
+### fun-line (`dev/fun-line`)
+Required extra checks:
+- plugin payload files present in live path
+- kiosk/chromium/Xorg runtime remains healthy after deploy
+
+Recommended `verify_pi_postdeploy_v1.sh` checks:
+- UI route render check
+- process stability check over short interval
+
+### starter (`dev/starter`)
+Required extra checks:
+- deploy contract normalization checks
+- runtime entry and rollback clean-up checks
+
+### autoswitch (`dev/autoswitch`)
+Required extra checks:
+- switching triggers and runtime behavior checks
+- rollback restores previous expected state
+
+### hardware (`dev/hardware`)
+Required extra checks:
+- non-deploy hardware integration checks documented as observational metrics
+- no false claim of deploy support if lane is non-deploy
+
+## Evidence bundle minimum template
+For each run include:
+- `summary.json`
+- `checks.jsonl`
+- `environment.txt`
+- `service_status.txt`
+- `process_snapshot.txt`
+- `notes.md`
+
+## Report generation
+Use the side tool:
+- `python3 tools/governance/pi_test_results_report_v1.py --root artifacts/pi-test-results --out artifacts/pi-test-results/report.md`
+
+The report includes:
+- component pass/fail summary table
+- duration averages
+- Mermaid chart blocks for quick visual trend review in GitHub markdown

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -80,16 +80,17 @@ The system-integration stream operates as the control-plane function set for the
 18. `contracts/repo/governance_unification_delivery_plan_v1.md`
 19. `docs/agents/agent_git_bootstrap_v1.md`
 20. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
-21. `docs/agents/status_prompt_reports_v1.md`
-22. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
-23. `tools/governance/scale_radio_governance_delivery_views_v1.md`
-24. `docs/agents/owner_operational_reference_v1.md`
-25. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-26. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-27. `journals/system-integration-normalization/stream_v6.md`
-28. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-29. `journals/scale-radio-bridge/current_state_v1.md`
-30. `journals/scale-radio-tuner/current_state_v2.md`
+21. `contracts/repo/deployment_test_strategy_standard_v1.md`
+22. `docs/agents/status_prompt_reports_v1.md`
+23. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
+24. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+25. `docs/agents/owner_operational_reference_v1.md`
+26. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+27. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+28. `journals/system-integration-normalization/stream_v6.md`
+29. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+30. `journals/scale-radio-bridge/current_state_v1.md`
+31. `journals/scale-radio-tuner/current_state_v2.md`
 
 ## Locked operating rules
 - `main` is the protected truth branch and final owner acceptance gate

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -216,3 +216,10 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - updated owner operational reference and SI read chains to include status prompt/report automation paths
 - locked SI decisions/status entries for this operating model (`DEC-system_integration_normalization-32`, `DEC-SIN-25`)
 - purpose: allow simple prompts like `status tuner` to return short, visual, link-backed outputs from Git-truth data
+
+### 2026-04-15 / si/deploy-test-strategy-v1 / measurable Pi deployment test strategy and component guide
+- added `contracts/repo/deployment_test_strategy_standard_v1.md` defining measurable run metrics, evidence bundle contract, layered checks, pass/fail rule, and chart/report generation expectations
+- added `docs/agents/pi_component_test_guide_v1.md` with per-component test checklist guidance and execution flow for standard + component-specific verification scripts
+- added `tools/governance/pi_test_results_report_v1.py` to aggregate run bundles and emit markdown summary tables plus Mermaid charts for pass-rate and deploy-duration trends
+- updated SI governance index and SI onboarding read orders to include the new deploy-test strategy standard
+- purpose: ensure each Pi test run yields structured, comparable, and visualizable data for owner decisions and autonomy gating

--- a/tools/governance/pi_test_results_report_v1.py
+++ b/tools/governance/pi_test_results_report_v1.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+
+def load_summary_files(root: Path):
+    for summary_path in sorted(root.glob("*/**/summary.json")):
+        try:
+            data = json.loads(summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        component = data.get("component") or summary_path.parts[-3]
+        yield {
+            "component": component,
+            "run_id": data.get("run_id") or summary_path.parent.name,
+            "status": data.get("status", "unknown"),
+            "deploy_duration_sec": float(data.get("deploy_duration_sec", 0) or 0),
+            "healthcheck_duration_sec": float(data.get("healthcheck_duration_sec", 0) or 0),
+            "rollback_duration_sec": float(data.get("rollback_duration_sec", 0) or 0),
+        }
+
+
+def aggregate(rows):
+    by_component = {}
+    for row in rows:
+        c = row["component"]
+        by_component.setdefault(c, []).append(row)
+
+    out = []
+    for component, items in sorted(by_component.items()):
+        total = len(items)
+        passed = sum(1 for i in items if i["status"] == "pass")
+        avg_deploy = sum(i["deploy_duration_sec"] for i in items) / total
+        avg_health = sum(i["healthcheck_duration_sec"] for i in items) / total
+        avg_rollback = sum(i["rollback_duration_sec"] for i in items) / total
+        out.append(
+            {
+                "component": component,
+                "runs": total,
+                "passed": passed,
+                "pass_rate": passed / total if total else 0,
+                "avg_deploy": avg_deploy,
+                "avg_health": avg_health,
+                "avg_rollback": avg_rollback,
+            }
+        )
+    return out
+
+
+def to_markdown(agg):
+    lines = []
+    lines.append("# Pi Test Results Report v1")
+    lines.append("")
+    lines.append("## Summary table")
+    lines.append("")
+    lines.append("| Component | Runs | Passed | Pass Rate | Avg Deploy (s) | Avg Health (s) | Avg Rollback (s) |")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|")
+    for r in agg:
+        lines.append(
+            f"| {r['component']} | {r['runs']} | {r['passed']} | {r['pass_rate']:.2%} | {r['avg_deploy']:.1f} | {r['avg_health']:.1f} | {r['avg_rollback']:.1f} |"
+        )
+
+    lines.append("")
+    lines.append("## Pass-rate chart (Mermaid)")
+    lines.append("")
+    lines.append("```mermaid")
+    lines.append("xychart-beta")
+    lines.append('    title "Component pass rate"')
+    labels = ", ".join(f'"{r["component"]}"' for r in agg)
+    values = ", ".join(f"{r['pass_rate']*100:.1f}" for r in agg)
+    lines.append(f"    x-axis [{labels}]")
+    lines.append('    y-axis "Pass %" 0 --> 100')
+    lines.append(f"    bar [{values}]")
+    lines.append("```")
+
+    lines.append("")
+    lines.append("## Avg deploy duration chart (Mermaid)")
+    lines.append("")
+    lines.append("```mermaid")
+    lines.append("xychart-beta")
+    lines.append('    title "Average deploy duration (seconds)"')
+    lines.append(f"    x-axis [{labels}]")
+    max_deploy = max((r["avg_deploy"] for r in agg), default=0)
+    ymax = int(max(10, max_deploy * 1.2))
+    deploy_vals = ", ".join(f"{r['avg_deploy']:.1f}" for r in agg)
+    lines.append(f'    y-axis "Seconds" 0 --> {ymax}')
+    lines.append(f"    bar [{deploy_vals}]")
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate markdown report from Pi test run bundles.")
+    parser.add_argument("--root", required=True, help="Root directory containing artifacts/pi-test-results")
+    parser.add_argument("--out", required=True, help="Output markdown file path")
+    args = parser.parse_args()
+
+    rows = list(load_summary_files(Path(args.root)))
+    agg = aggregate(rows)
+    markdown = to_markdown(agg)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(markdown, encoding="utf-8")
+    print(f"wrote_report={out_path}")
+    print(f"components={len(agg)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `contracts/repo/deployment_test_strategy_standard_v1.md` with measurable run metrics, evidence-bundle contract, layered checks, pass/fail rules, and script model for standard + component-specific verification
- add `docs/agents/pi_component_test_guide_v1.md` with per-component checklists and required evidence collection flow
- add `tools/governance/pi_test_results_report_v1.py` to aggregate Pi run bundles and emit markdown + Mermaid charts
- update SI governance index and SI onboarding read order to include the new strategy standard
- log this packaged change in SI stream

## Validation
- `bash -n tools/governance/agent_git_bootstrap_v1.sh tools/governance/container_startup_setup_v1.sh`
- `python3 -m py_compile tools/governance/pi_test_results_report_v1.py`
- `python3 tools/governance/pi_test_results_report_v1.py --root artifacts/pi-test-results --out /tmp/pi_test_report.md`
- `rg -n "deployment_test_strategy_standard_v1|pi_component_test_guide_v1|si/deploy-test-strategy-v1" contracts/repo/system_integration_governance_index_v7.md docs/agents/system_integration_recovery_onboarding_v7.md journals/system-integration-normalization/stream_v6.md docs/agents/pi_component_test_guide_v1.md contracts/repo/deployment_test_strategy_standard_v1.md`