### PR TITLE
Add click-based owner decision automation with rollback and robustness checks

### DIFF
--- a/.github/workflows/governance-model-robustness-check-v1.yml
+++ b/.github/workflows/governance-model-robustness-check-v1.yml
@@ -1,0 +1,24 @@
+name: governance-model-robustness-check-v1
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    paths:
+      - 'contracts/repo/**'
+      - 'docs/agents/**'
+      - '.github/workflows/**'
+      - 'tools/governance/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  robustness_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run governance model robustness check
+        shell: bash
+        run: |
+          python3 tools/governance/governance_model_robustness_check_v1.py

--- a/.github/workflows/owner-decision-click-sync.yml
+++ b/.github/workflows/owner-decision-click-sync.yml
@@ -1,0 +1,149 @@
+name: owner-decision-click-sync
+
+on:
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number"
+        required: true
+      decision:
+        description: "accept | changes-requested | reject"
+        required: true
+      merge_authorization:
+        description: "yes | no"
+        required: true
+      docs_journals_complete:
+        description: "yes | no"
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync_owner_decision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync structured owner decision to labels
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          EVENT_IS_PR: ${{ github.event.issue.pull_request.url }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_DECISION: ${{ inputs.decision }}
+          INPUT_MERGE: ${{ inputs.merge_authorization }}
+          INPUT_DOCS: ${{ inputs.docs_journals_complete }}
+          OWNER_DECISION_AUTOMATION_ENABLED: ${{ vars.OWNER_DECISION_AUTOMATION_ENABLED }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re, urllib.request
+
+          repo = os.environ['GITHUB_REPOSITORY']
+          token = os.environ['GITHUB_TOKEN']
+          base = f'https://api.github.com/repos/{repo}'
+          headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'owner-decision-click-sync'
+          }
+
+          def req(method, path, data=None):
+            body = None if data is None else json.dumps(data).encode('utf-8')
+            h = dict(headers)
+            if body is not None:
+              h['Content-Type'] = 'application/json'
+            r = urllib.request.Request(base + path, data=body, headers=h, method=method)
+            with urllib.request.urlopen(r) as resp:
+              raw = resp.read().decode('utf-8')
+              return json.loads(raw) if raw else None
+
+          enabled = (os.environ.get('OWNER_DECISION_AUTOMATION_ENABLED') or 'true').strip().lower()
+          if enabled in ('false', '0', 'no', 'off'):
+            print('automation_disabled=true')
+            raise SystemExit(0)
+
+          event_name = os.environ.get('EVENT_NAME')
+          pr_number = None
+          decision = None
+          merge_auth = None
+          docs_done = None
+
+          if event_name == 'workflow_dispatch':
+            pr_number = (os.environ.get('INPUT_PR_NUMBER') or '').strip()
+            decision = (os.environ.get('INPUT_DECISION') or '').strip().lower()
+            merge_auth = (os.environ.get('INPUT_MERGE') or '').strip().lower()
+            docs_done = (os.environ.get('INPUT_DOCS') or '').strip().lower()
+          else:
+            issue_number = (os.environ.get('EVENT_ISSUE_NUMBER') or '').strip()
+            is_pr = (os.environ.get('EVENT_IS_PR') or '').strip()
+            body = os.environ.get('COMMENT_BODY') or ''
+            if not issue_number or not is_pr:
+              raise SystemExit(0)
+            if '<!-- owner-decision-v1 -->' not in body:
+              raise SystemExit(0)
+            pr_number = issue_number
+
+            def pick(name):
+              m = re.search(rf'^{name}\s*:\s*(.+)$', body, flags=re.IGNORECASE | re.MULTILINE)
+              return (m.group(1).strip().lower() if m else '')
+
+            decision = pick('decision')
+            merge_auth = pick('merge_authorization')
+            docs_done = pick('docs_journals_complete')
+
+          if not pr_number:
+            raise SystemExit(0)
+
+          valid_decisions = {'accept', 'changes-requested', 'reject'}
+          valid_yesno = {'yes', 'no'}
+
+          if decision not in valid_decisions or merge_auth not in valid_yesno or docs_done not in valid_yesno:
+            marker = '<!-- owner-decision-sync:blocker -->'
+            msg = '\n'.join([
+              marker,
+              'Owner decision sync blocked: invalid or incomplete decision fields.',
+              '',
+              'Required fields:',
+              '- decision: accept | changes-requested | reject',
+              '- merge_authorization: yes | no',
+              '- docs_journals_complete: yes | no',
+            ])
+            req('POST', f'/issues/{pr_number}/comments', {'body': msg})
+            raise SystemExit(0)
+
+          issue = req('GET', f'/issues/{pr_number}')
+          existing = [l['name'] for l in issue.get('labels', [])]
+          state_labels = {'state:needs-triage','state:ready-for-agent','state:needs-decision','state:awaiting-owner','state:docs-update-required','state:done'}
+          labels = [l for l in existing if l not in state_labels]
+
+          if decision == 'accept' and merge_auth == 'yes' and docs_done == 'yes':
+            state = 'state:awaiting-owner'
+          elif decision == 'accept' and merge_auth == 'yes' and docs_done == 'no':
+            state = 'state:docs-update-required'
+          elif decision == 'changes-requested':
+            state = 'state:ready-for-agent'
+          else:
+            state = 'state:done'
+
+          labels.append(state)
+          labels.append('source:owner-click-decision')
+          req('PATCH', f'/issues/{pr_number}', {'labels': sorted(set(labels))})
+
+          summary = '\n'.join([
+            '<!-- owner-decision-sync:applied -->',
+            'Owner decision sync applied.',
+            f'- decision: `{decision}`',
+            f'- merge_authorization: `{merge_auth}`',
+            f'- docs_journals_complete: `{docs_done}`',
+            f'- resulting state label: `{state}`'
+          ])
+          req('POST', f'/issues/{pr_number}/comments', {'body': summary})
+          print(f'pr={pr_number} state={state}')
+          PY

--- a/contracts/repo/owner_decision_click_automation_standard_v1.md
+++ b/contracts/repo/owner_decision_click_automation_standard_v1.md
@@ -1,0 +1,55 @@
+# OWNER DECISION CLICK AUTOMATION STANDARD V1
+
+## Purpose
+This standard reduces owner comment overhead by introducing a structured click/selection decision path for PR governance outcomes.
+
+## Core model
+Owner decisions should be captured through structured fields (Project custom fields or fallback structured comment) and synchronized into governed PR labels.
+
+## Decision fields
+Minimum required fields:
+- `decision`: `accept | changes-requested | reject`
+- `merge_authorization`: `yes | no`
+- `docs_journals_complete`: `yes | no`
+
+Optional fields:
+- `scope`
+- `followup_note`
+
+## Click-path precedence
+1. Project custom fields on the owner queue item (preferred click-path).
+2. Structured PR comment block with marker `<!-- owner-decision-v1 -->` (fallback when project-field API bridge is unavailable).
+
+## Label synchronization contract
+Owner decision synchronization should maintain exactly one active state label:
+- `accept + merge_authorization=yes + docs_journals_complete=yes` -> `state:awaiting-owner`
+- `accept + merge_authorization=yes + docs_journals_complete=no` -> `state:docs-update-required`
+- `changes-requested` -> `state:ready-for-agent`
+- `reject` -> `state:done`
+
+## Rollback model (mandatory)
+Automation must be reversible without history loss:
+- feature-flag gate: `OWNER_DECISION_AUTOMATION_ENABLED`
+- rollback action: disable flag and revert to manual owner comments/labels
+- no destructive mutation of journals or decision logs during rollback
+- synchronization comments remain as evidence trail
+
+## Satellite processes that must stay aligned
+- owner operational reference
+- project view blueprint and field definitions
+- PR governance review workflow
+- governance closeout workflow
+- SI status/decision/stream logs
+
+## Robustness double-check
+Before enabling on `main`, run governance-model robustness checks to verify:
+- required docs/workflows/scripts exist
+- owner decision field contract is present
+- rollback flag path is documented
+- structured fallback marker path is available
+
+## Safety rule
+If parsing fails or fields are incomplete:
+- do not apply destructive label changes
+- emit explicit blocker comment with required owner action
+- prefer truthful negative status over assumed decision

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -29,15 +29,17 @@ This file is the current entrypoint for system integration governance, recovery,
 17. `contracts/repo/governance_unification_delivery_plan_v1.md`
 18. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
 19. `contracts/repo/deployment_test_strategy_standard_v1.md`
-20. `docs/agents/agent_git_bootstrap_v1.md`
-21. `docs/agents/status_prompt_reports_v1.md`
-22. `docs/agents/system_integration_recovery_onboarding_v7.md`
-23. `docs/agents/owner_operational_reference_v1.md`
-24. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-25. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-26. `journals/system-integration-normalization/stream_v6.md`
-27. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-28. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+20. `contracts/repo/owner_decision_click_automation_standard_v1.md`
+21. `docs/agents/agent_git_bootstrap_v1.md`
+22. `docs/agents/status_prompt_reports_v1.md`
+23. `docs/agents/system_integration_recovery_onboarding_v7.md`
+24. `docs/agents/owner_operational_reference_v1.md`
+25. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+26. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+27. `journals/system-integration-normalization/stream_v6.md`
+28. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+29. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+
 
 ## Locked operating model
 - the repository remains public until further notice

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -19,6 +19,21 @@ Use this short format in chat or PR comment:
 - `mandatory follow-up: <required change>`
 - `merge authorization: yes | no`
 
+
+## Click-based owner decision (project/custom-field compatible)
+Preferred: set decision via project custom fields.
+Fallback: post this structured PR comment block:
+
+```text
+<!-- owner-decision-v1 -->
+decision: accept
+merge_authorization: yes
+docs_journals_complete: yes
+```
+
+Automation syncs labels/state from this block through `owner-decision-click-sync.yml`.
+Rollback switch: set repository variable `OWNER_DECISION_AUTOMATION_ENABLED=false` to disable automation and return to manual labeling/comments.
+
 ## Are we ready to develop? (YES/NO gate)
 Answer **YES** only if all are true:
 1. `main` is protected and PR-gated.
@@ -88,6 +103,8 @@ Interpretation:
 - [System integration escalation workflow](../../.github/workflows/system-integration-escalation.yml)
 - [Open decision issues workflow](../../.github/workflows/open-decision-issues.yml)
 - [Governance closeout workflow](../../.github/workflows/governance-closeout.yml)
+- [owner-decision-click-sync workflow](../../.github/workflows/owner-decision-click-sync.yml)
+- [governance-model-robustness-check-v1 workflow](../../.github/workflows/governance-model-robustness-check-v1.yml)
 
 ### Governance panel/view references
 - [Project views blueprint](../../tools/governance/scale_radio_governance_delivery_views_v1.md)

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -81,16 +81,18 @@ The system-integration stream operates as the control-plane function set for the
 19. `docs/agents/agent_git_bootstrap_v1.md`
 20. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
 21. `contracts/repo/deployment_test_strategy_standard_v1.md`
-22. `docs/agents/status_prompt_reports_v1.md`
-23. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
-24. `tools/governance/scale_radio_governance_delivery_views_v1.md`
-25. `docs/agents/owner_operational_reference_v1.md`
-26. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-27. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-28. `journals/system-integration-normalization/stream_v6.md`
-29. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-30. `journals/scale-radio-bridge/current_state_v1.md`
-31. `journals/scale-radio-tuner/current_state_v2.md`
+22. `contracts/repo/owner_decision_click_automation_standard_v1.md`
+23. `docs/agents/status_prompt_reports_v1.md`
+24. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
+25. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+26. `docs/agents/owner_operational_reference_v1.md`
+27. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+28. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+29. `journals/system-integration-normalization/stream_v6.md`
+30. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+31. `journals/scale-radio-bridge/current_state_v1.md`
+32. `journals/scale-radio-tuner/current_state_v2.md`
+
 
 ## Locked operating rules
 - `main` is the protected truth branch and final owner acceptance gate

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
@@ -176,3 +176,12 @@ Status note: this v9 file remains the current SI/N decision addendum and is upda
 - Follow-up needed: keep report generator aligned with journal/status schemas and run report generation after material status changes.
 ## Superseded Decisions
 - The earlier v8 truthfulness addendum remains historical; this v9 file is the current release-tagging addendum plus tuner autonomy promotion update.
+
+### DEC-system_integration_normalization-31
+- Status: locked
+- Decision: owner decision handling uses a click-first structured model with project custom fields and a governed fallback structured PR comment (`<!-- owner-decision-v1 -->`) synchronized by workflow.
+- Date context: owner decision friction reduction phase
+- Why this was chosen: repeated free-text PR comments increase owner overhead and reduce deterministic automation.
+- What it affects: owner PR decision flow, state-label synchronization, governance closeout readiness, and review click-path.
+- What it explicitly does NOT affect: protected-`main` merge approval authority or the requirement for docs/journal truth updates.
+- Follow-up needed: keep rollback switch and robustness checks active; disable automation quickly through `OWNER_DECISION_AUTOMATION_ENABLED=false` if behavior degrades.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
@@ -111,6 +111,12 @@ Status note: this v8 file remains the current SI/N status addendum and is update
 - decision: status prompts are fulfilled via generated repo pages under `reports/status/` with clickable source links and compact visual summaries.
 - rationale: reduces owner and agent overhead for recurring status requests and keeps outputs anchored to Git truth.
 - impact: status handling for `status tuner|governance|ui|bridge|decisions|blocker` now maps to generated markdown artifacts.
+
+### DEC-SIN-24
+- decision: owner decision handling is click-first via project custom fields with structured PR-comment fallback (`<!-- owner-decision-v1 -->`) and label sync automation.
+- rationale: reduces repetitive owner comment overhead while preserving auditable and deterministic state transitions.
+- impact: PR decision flow, state-label synchronization, and owner approval queue handling.
+
 ## 5. Open Decisions
 - when additional components beyond bridge, tuner, and fun-line become delivery-capable in the autonomous support matrix
 - whether the repository should later move to private visibility if the cost/risk tradeoff changes

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -229,3 +229,12 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - migrated the two recent tuner stream entries (deploy-scope revalidation and pointer/overlay tuning update) into `stream_v2.md` to preserve chronology in the active stream
 - updated `contracts/repo/component_journal_policy_v2.md` with an explicit versioned-journal rule: write new entries only to the latest generation and keep older generations historical
 - purpose: prevent governance drift from writing to deprecated journal paths and keep component truth chronologically consistent
+
+### 2026-04-16 / si/owner-decision-click-automation-v1 / click-first owner decision automation with rollback
+- added `contracts/repo/owner_decision_click_automation_standard_v1.md` defining click-first decision fields, fallback structured comment path, label-sync contract, rollback switch, and required satellite-process alignment
+- added `.github/workflows/owner-decision-click-sync.yml` to synchronize structured owner decisions into governed PR state labels, with explicit blocker comments on invalid payloads
+- added `tools/governance/governance_model_robustness_check_v1.py` and `.github/workflows/governance-model-robustness-check-v1.yml` as double-check controls before and during governance changes
+- updated owner operational reference and project-view blueprint with custom-field definitions, fallback marker, and rollback flag (`OWNER_DECISION_AUTOMATION_ENABLED=false`)
+- updated SI governance read chains and SI decision/status logs to lock this operating model
+- purpose: reduce owner PR-comment friction while preserving full rollback capability and governance robustness checks
+

--- a/tools/governance/governance_model_robustness_check_v1.py
+++ b/tools/governance/governance_model_robustness_check_v1.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+import re
+from pathlib import Path
+
+REQUIRED_FILES = [
+    'contracts/repo/owner_decision_click_automation_standard_v1.md',
+    'docs/agents/owner_operational_reference_v1.md',
+    'tools/governance/scale_radio_governance_delivery_views_v1.md',
+    '.github/workflows/owner-decision-click-sync.yml',
+    '.github/workflows/pr-governance-review.yml',
+    '.github/workflows/governance-closeout.yml',
+]
+
+
+def must_exist(root: Path, rel: str, failures: list):
+    p = root / rel
+    if not p.exists():
+        failures.append(f'missing_file:{rel}')
+
+
+def must_contain(root: Path, rel: str, pattern: str, failures: list):
+    p = root / rel
+    if not p.exists():
+        failures.append(f'missing_for_pattern:{rel}')
+        return
+    text = p.read_text(encoding='utf-8')
+    if not re.search(pattern, text, flags=re.MULTILINE):
+        failures.append(f'missing_pattern:{rel}:{pattern}')
+
+
+def main():
+    root = Path(__file__).resolve().parents[2]
+    failures = []
+
+    for rel in REQUIRED_FILES:
+        must_exist(root, rel, failures)
+
+    must_contain(root, 'contracts/repo/owner_decision_click_automation_standard_v1.md', r'OWNER_DECISION_AUTOMATION_ENABLED', failures)
+    must_contain(root, '.github/workflows/owner-decision-click-sync.yml', r'owner-decision-v1', failures)
+    must_contain(root, '.github/workflows/owner-decision-click-sync.yml', r'OWNER_DECISION_AUTOMATION_ENABLED', failures)
+    must_contain(root, 'docs/agents/owner_operational_reference_v1.md', r'decision\s*:\s*accept \| changes-requested \| reject', failures)
+
+    if failures:
+        print('governance_model_robustness=fail')
+        for f in failures:
+            print(f)
+        raise SystemExit(1)
+
+    print('governance_model_robustness=ok')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/governance/scale_radio_governance_delivery_views_v1.md
+++ b/tools/governance/scale_radio_governance_delivery_views_v1.md
@@ -89,3 +89,15 @@ Companion renderings:
 
 ## Minimum operational expectation
 If direct API setup for project views is blocked in the execution environment, keep this blueprint in repo truth and apply once with owner credentials.
+
+
+## Custom fields for click-based owner decisions
+Create these project custom fields:
+- `Owner Decision` (single-select): `accept`, `changes-requested`, `reject`
+- `Merge Authorization` (single-select): `yes`, `no`
+- `Docs/Journals Complete` (single-select): `yes`, `no`
+
+Operational rule:
+- if project-field automation API is unavailable in the active lane, use the structured PR comment fallback (`<!-- owner-decision-v1 -->`) and let workflow sync labels.
+- rollback path: disable decision sync with repository variable `OWNER_DECISION_AUTOMATION_ENABLED=false`.
+


### PR DESCRIPTION
## Summary
- add click-first owner decision standard with structured fallback and rollback switch
- add owner decision sync workflow (`owner-decision-click-sync.yml`)
- add governance robustness checker script + workflow
- update owner reference, project view blueprint, SI read chains, and SI decision/status/stream logs

## Rollback
- set repository variable `OWNER_DECISION_AUTOMATION_ENABLED=false` to disable decision sync and revert to manual comments/labels

## Validation
- `python3 tools/governance/governance_model_robustness_check_v1.py`
- `python3 -m py_compile tools/governance/governance_model_robustness_check_v1.py`
- `rg -n "owner_decision_click_automation_standard_v1|owner-decision-v1|OWNER_DECISION_AUTOMATION_ENABLED|DEC-system_integration_normalization-31|DEC-SIN-24|owner-decision-click-sync" contracts/repo/system_integration_governance_index_v7.md docs/agents/system_integration_recovery_onboarding_v7.md contracts/repo/owner_decision_click_automation_standard_v1.md docs/agents/owner_operational_reference_v1.md tools/governance/scale_radio_governance_delivery_views_v1.md journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md journals/system-integration-normalization/stream_v6.md .github/workflows/owner-decision-click-sync.yml .github/workflows/governance-model-robustness-check-v1.yml`