### PR TITLE
Stabilize status report generator outputs and add owner merge/rollback playbook

### DIFF
--- a/.github/workflows/status-report-generation-v1.yml
+++ b/.github/workflows/status-report-generation-v1.yml
@@ -1,0 +1,28 @@
+name: status-report-generation-v1
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'journals/**'
+      - 'reports/status/**'
+      - 'tools/governance/generate_status_reports_v1.py'
+      - 'docs/agents/status_prompt_reports_v1.md'
+
+permissions:
+  contents: read
+
+jobs:
+  generate_status_reports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate status reports
+        shell: bash
+        run: |
+          python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status
+      - name: Upload status-report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: status-reports-v1
+          path: reports/status/

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -29,13 +29,14 @@ This file is the current entrypoint for system integration governance, recovery,
 17. `contracts/repo/governance_unification_delivery_plan_v1.md`
 18. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
 19. `docs/agents/agent_git_bootstrap_v1.md`
-20. `docs/agents/system_integration_recovery_onboarding_v7.md`
-21. `docs/agents/owner_operational_reference_v1.md`
-22. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-23. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-24. `journals/system-integration-normalization/stream_v6.md`
-25. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-26. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+20. `docs/agents/status_prompt_reports_v1.md`
+21. `docs/agents/system_integration_recovery_onboarding_v7.md`
+22. `docs/agents/owner_operational_reference_v1.md`
+23. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+24. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+25. `journals/system-integration-normalization/stream_v6.md`
+26. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+27. `tools/governance/scale_radio_governance_delivery_views_v1.md`
 
 ## Locked operating model
 - the repository remains public until further notice

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -79,6 +79,7 @@ Interpretation:
 - [Container startup setup](./container_startup_setup_v1.md)
 - [Chat-to-Git delivery process](./chat_to_git_delivery_process_v1.md)
 - [Connector-blocked fallback manual](./fallback_connector_blocked_manual_v1.md)
+- [Status prompt/report automation guide](./status_prompt_reports_v1.md)
 
 ### Intake and governance automation
 - [Governed demand intake template](../../.github/ISSUE_TEMPLATE/governed-demand-intake.yml)
@@ -93,6 +94,23 @@ Interpretation:
 - [Project views table rendering](../../tools/governance/scale_radio_governance_delivery_views_table_v1.md)
 - [Project views kanban rendering](../../tools/governance/scale_radio_governance_delivery_views_kanban_v1.md)
 
+## Prompt-ready status pages
+Use these prompt aliases in ChatGPT/Codex:
+- `status tuner`
+- `status governance`
+- `status ui`
+- `status bridge`
+- `status decisions`
+- `status blocker`
+
+Generated pages:
+- [Status index](../../reports/status/index.md)
+- [Status tuner](../../reports/status/tuner.md)
+- [Status governance](../../reports/status/governance.md)
+- [Status ui](../../reports/status/ui.md)
+- [Status bridge](../../reports/status/bridge.md)
+- [Status decisions](../../reports/status/decisions.md)
+- [Status blocker](../../reports/status/blocker.md)
 ## Current recurring setup topics to monitor
 - runtime token injection drift (`GH_TOKEN` / `GITHUB_TOKEN` not visible in active runtime session)
 - branch discipline drift (agent starts on `work` instead of `dev/*` or `si/*`)

--- a/docs/agents/owner_pr_merge_sequence_and_rollback_v1.md
+++ b/docs/agents/owner_pr_merge_sequence_and_rollback_v1.md
@@ -1,0 +1,66 @@
+# OWNER PR MERGE SEQUENCE AND ROLLBACK PLAYBOOK V1
+
+## Purpose
+Provide a low-click, governance-safe merge sequence to `main`, including explicit rollback paths for wrong decisions.
+
+## Quick links
+- [Current open PRs (repo)](https://github.com/SH99999/mediastreamer/pulls)
+- [Create PR for missing SI follow-up branch](https://github.com/SH99999/mediastreamer/compare/main...si/fun-line-followups-v1?expand=1)
+- [Component deploy workflow v10](../../.github/workflows/component-test-deploy-v10.yml)
+- [Component rollback workflow v10](../../.github/workflows/component-test-rollback-v10.yml)
+- [Deploy process standard](../../contracts/repo/deploy_process_standard_v1.md)
+- [Protected-main maintenance model](../../contracts/repo/protected_main_truth_maintenance_operating_model_v1.md)
+- [SI governance index](../../contracts/repo/system_integration_governance_index_v7.md)
+
+## Topic index
+- [1) Mandatory guardrails](#1-mandatory-guardrails)
+- [2) PRs to open if missing](#2-prs-to-open-if-missing)
+- [3) Safe merge order into main](#3-safe-merge-order-into-main)
+- [4) Rollback plan if owner decision is wrong](#4-rollback-plan-if-owner-decision-is-wrong)
+- [5) Owner click-path checklist](#5-owner-click-path-checklist)
+
+## 1) Mandatory guardrails
+1. Never merge from `work`.
+2. SI/governance changes must come from dedicated `si/<topic>` branches.
+3. Merge only through reviewed PRs to protected `main`.
+4. Keep rollback possible before and after merge.
+
+## 2) PRs to open if missing
+Open a PR if this branch has no PR yet:
+- `si/fun-line-followups-v1` -> `main`
+- suggested title: `Stabilize status report generator outputs and merge sequence guidance`
+- suggested labels: `governance`, `agent:system-integration`, `component:system-integration`, `impact:system-wide`
+
+## 3) Safe merge order into main
+Use this order to avoid governance drift and preserve rollback clarity:
+1. **PR-A (first):** `si/fun-line-followups-v1` -> `main` (this branch; includes follow-up fixes and owner playbook)
+2. **PR-B:** `#92` measurable deploy test strategy (if still open and green)
+3. **PR-C:** `#93` tuner journal normalization (if still open and green)
+4. **PR-D:** `#94` owner decision click automation (merge last because it changes control-plane decision flow)
+5. **PR-E:** `#85` faceplate intake only after confirming no conflicts with newer governance docs
+
+If any PR conflicts with already merged truth, rebase that PR branch to `main`, re-run checks, and re-review before merge.
+
+## 4) Rollback plan if owner decision is wrong
+### Runtime rollback (Pi/plugin state)
+Run workflow `component-test-rollback-v10` with:
+- `git_ref=main`
+- `component=fun-line` (or `tuner`)
+- `payload=current`
+- `target=primary` (or intended slot)
+
+### Repo-truth rollback (governance/docs/workflow state)
+1. Create `si/revert-<topic>` from `main`.
+2. `git revert <merge_commit_sha>` (or a bounded range if needed).
+3. Open PR `si/revert-<topic>` -> `main` with clear revert rationale.
+4. Merge after owner review.
+
+### Mandatory rollback note
+Do not force-push to `main`; rollback must be explicit, reviewable, and journal-traceable.
+
+## 5) Owner click-path checklist
+1. Open PR list and confirm branch/source/target are correct.
+2. Merge PR-A first (`si/fun-line-followups-v1`).
+3. Validate rollback workflow visibility and input defaults.
+4. Merge PR-B, PR-C, PR-D, PR-E one-by-one (no batch merges).
+5. After each merge, verify no open blocker in SI status and that next PR rebases cleanly.

--- a/docs/agents/status_prompt_reports_v1.md
+++ b/docs/agents/status_prompt_reports_v1.md
@@ -10,6 +10,12 @@ Run:
 python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status
 ```
 
+Deterministic timestamp mode (optional, useful for reproducible regeneration during review):
+
+```bash
+python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status --generated-at 2026-04-16T00:00:00+00:00
+```
+
 Generated files:
 - `reports/status/index.md`
 - `reports/status/tuner.md`

--- a/docs/agents/status_prompt_reports_v1.md
+++ b/docs/agents/status_prompt_reports_v1.md
@@ -1,0 +1,38 @@
+# STATUS PROMPT REPORTS V1
+
+## Purpose
+Enable short prompt-based status responses with pre-generated, clickable, and visualized markdown reports.
+
+## Generator
+Run:
+
+```bash
+python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status
+```
+
+Generated files:
+- `reports/status/index.md`
+- `reports/status/tuner.md`
+- `reports/status/governance.md`
+- `reports/status/ui.md`
+- `reports/status/bridge.md`
+- `reports/status/decisions.md`
+- `reports/status/blocker.md`
+
+## Prompt aliases
+- `status tuner`
+- `status governance`
+- `status ui`
+- `status bridge`
+- `status decisions`
+- `status blocker`
+
+## Output contract
+Each report must provide:
+- short bullet summary
+- clickable links to source objects in repository
+- visual block (Mermaid chart)
+- concise next-action context where available
+
+## Source-of-truth rule
+Reports are generated from repo truth files so prompts can be handled without hidden external state.

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -80,15 +80,16 @@ The system-integration stream operates as the control-plane function set for the
 18. `contracts/repo/governance_unification_delivery_plan_v1.md`
 19. `docs/agents/agent_git_bootstrap_v1.md`
 20. `contracts/repo/ui_ux_stage_b_autonomous_loop_standard_v1.md`
-21. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
-22. `tools/governance/scale_radio_governance_delivery_views_v1.md`
-23. `docs/agents/owner_operational_reference_v1.md`
-24. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
-25. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
-26. `journals/system-integration-normalization/stream_v6.md`
-27. `journals/system-integration-normalization/ui_gui_stream_v1.md`
-28. `journals/scale-radio-bridge/current_state_v1.md`
-29. `journals/scale-radio-tuner/current_state_v2.md`
+21. `docs/agents/status_prompt_reports_v1.md`
+22. `docs/agents/chatgpt_governed_intake_prompt_v1.md`
+23. `tools/governance/scale_radio_governance_delivery_views_v1.md`
+24. `docs/agents/owner_operational_reference_v1.md`
+25. `journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md`
+26. `journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md`
+27. `journals/system-integration-normalization/stream_v6.md`
+28. `journals/system-integration-normalization/ui_gui_stream_v1.md`
+29. `journals/scale-radio-bridge/current_state_v1.md`
+30. `journals/scale-radio-tuner/current_state_v2.md`
 
 ## Locked operating rules
 - `main` is the protected truth branch and final owner acceptance gate

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
@@ -166,5 +166,13 @@ Status note: this v9 file remains the current SI/N decision addendum and is upda
 - What it explicitly does NOT affect: the still-open need to normalize the separate `radio_scale_source` artifact as part of the governed tuner component contract.
 - Follow-up needed: normalize the remaining source-artifact gap without disabling the validated overlay/runtime/service lane.
 
+### DEC-system_integration_normalization-32
+- Status: locked
+- Decision: prompt-ready status reporting is generated from repo truth into clickable markdown pages (`reports/status/*.md`) with concise summaries and Mermaid visuals for tuner, governance, UI, bridge, decisions, and blockers.
+- Date context: status-report automation phase
+- Why this was chosen: owner and chats need one-prompt status outputs without manual reconstruction from multiple files.
+- What it affects: status communication format, report generation tooling, and owner click-path speed.
+- What it explicitly does NOT affect: protected-main approval authority or runtime deployment contracts.
+- Follow-up needed: keep report generator aligned with journal/status schemas and run report generation after material status changes.
 ## Superseded Decisions
 - The earlier v8 truthfulness addendum remains historical; this v9 file is the current release-tagging addendum plus tuner autonomy promotion update.

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -209,3 +209,10 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - converted owner-relevant document and workflow lists to markdown links so the page is directly clickable in GitHub
 - added direct project board link (`https://github.com/users/SH99999/projects/1`) and daily owner click-path guidance
 - purpose: ensure owner can review and decide from one page with minimal navigation friction
+### 2026-04-16 / si/status-report-automation-v1 / prompt-ready status pages with visuals and clickable links
+- added `tools/governance/generate_status_reports_v1.py` to build prompt-ready status pages from repo truth for tuner, governance, UI, bridge, decisions, and blockers
+- generated and committed `reports/status/index.md` plus six status pages with concise bullets, clickable source links, and Mermaid visuals
+- added `docs/agents/status_prompt_reports_v1.md` and `status-report-generation-v1.yml` so report generation can run consistently and expose artifacts
+- updated owner operational reference and SI read chains to include status prompt/report automation paths
+- locked SI decisions/status entries for this operating model (`DEC-system_integration_normalization-32`, `DEC-SIN-25`)
+- purpose: allow simple prompts like `status tuner` to return short, visual, link-backed outputs from Git-truth data

--- a/reports/status/blocker.md
+++ b/reports/status/blocker.md
@@ -1,6 +1,6 @@
 # Status Blocker
 
-_Generated: 2026-04-16T06:17:21.921842+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Active broken points
 - unsupported components still cannot use autonomous delivery and must still escalate or no-op safely

--- a/reports/status/blocker.md
+++ b/reports/status/blocker.md
@@ -1,135 +1,76 @@
-# COMPONENT STATUS — system_integration_normalization
+# Status Blocker
 
-Status note: this v8 file remains the current SI/N status addendum and is updated here after successful tuner target-Pi validation and autonomy promotion.
+_Generated: 2026-04-16T06:17:21.921842+00:00_
 
-## 1. Scope
-- component name: system_integration_normalization
-- legacy names / aliases: SI/N, integration chat, normalization lane
-- responsibility boundaries: branch doctrine, workflow model, deploy semantics, rollback semantics, repo governance, release-path normalization, issue routing, escalation discipline, autonomous execution guardrails, cross-component normalization, protected-main truth maintenance operating model, target deploy/test exclusivity rules
-- non-goals: specialist feature implementation inside component payloads, UI/UX design ownership, hardware implementation, unsupported component delivery automation
-
-## 2. Current Functional Status
-- what currently works:
-  - governance, issue-routing, and reporting workflows exist on `main`
-  - one-click branch rebase exists for all current and future `dev/*` and `integration/*` branches
-  - weekly governance report issues are generated from repo truth
-  - open decisions, branch drift, and journal freshness can become governance-routed issues automatically
-  - PR governance review and governance closeout workflows are active
-  - new governed components can be bootstrapped via workflow
-  - release-readiness audit exists as a manual gate
-  - an autonomous execution doctrine and SI escalation contract exist in repo form
-  - a protected-main truth maintenance operating model exists for safe handling of connector mutation limits
-  - a target deploy/test exclusivity contract and lock-aware workflow family exist on `main`
-  - bridge deploy and rollback are validated on the target Pi
-  - tuner deploy and rollback are validated on the target Pi through the manual lock-aware workflow lane
-  - bridge and tuner are both enabled in the autonomous delivery support matrix
-- what partially works:
-  - autonomous delivery remains support-matrix gated, now including Bridge, Tuner, and Fun Line while other components remain unsupported
-  - top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts may still be required in some cases
-  - tuner deploy normalization is intentionally scoped to overlay/runtime/service while source-selection behavior remains hardware-governed (encoder short/long press) until full integration
-- what is broken:
-  - unsupported components still cannot use autonomous delivery and must still escalate or no-op safely
+## Active broken points
+- unsupported components still cannot use autonomous delivery and must still escalate or no-op safely
 - what was tested:
-  - governance reporting and routing layers were merged and are available on `main`
-  - project auto-add and project views were confirmed to work with the governance label model
-  - branch creation and new-file repo-truth updates through the connector are working
-  - bridge lock-aware deploy and rollback path are validated on the real Pi
-  - tuner lock-aware deploy and rollback path are validated on the real Pi
+- governance reporting and routing layers were merged and are available on `main`
+- project auto-add and project views were confirmed to work with the governance label model
+- branch creation and new-file repo-truth updates through the connector are working
+- bridge lock-aware deploy and rollback path are validated on the real Pi
+- tuner lock-aware deploy and rollback path are validated on the real Pi
 - what is untested:
-  - broader autonomous delivery beyond the current support matrix
-  - a future connector path for safe in-place mutation of all protected truth files
-
-## 3. Repository Mapping
+- broader autonomous delivery beyond the current support matrix
+- a future connector path for safe in-place mutation of all protected truth files
 - correct component path in repo: `journals/system-integration-normalization/`
 - active SI UI/GUI governance stream path: `journals/system-integration-normalization/ui_gui_stream_v1.md`
 - correct truth contracts: `contracts/repo/`
 - correct support data path: `tools/governance/`
 - correct branch model: `main` for truth; dedicated short-lived `si/<topic>` branches for SI/governance changes; `integration/staging` as an exception-only branch
-
-## 4. Locked Decisions
-### DEC-SIN-12
 - decision: issue routing is label-based and one central GitHub Project is used instead of one project per component.
 - rationale: low owner overhead and scalable routing.
 - impact: governance issues route by label, not by assignee.
-
-### DEC-SIN-13
 - decision: autonomous execution must minimize recurring owner administration and use governed repo workflows and repo truth.
 - rationale: the repo is becoming the operating system for the project.
 - impact: workflows and docs must favor auto-routing, auto-reporting, and safe escalation.
-
-### DEC-SIN-14
 - decision: cross-component and system-wide impact must escalate automatically to system integration / governance.
 - rationale: chat memory is not a safe integration bus.
 - impact: escalation workflows and labels are required.
-
-### DEC-SIN-15
 - decision: autonomous delivery must be support-matrix based and conservative.
 - rationale: not all components have normalized deploy/rollback contracts yet.
 - impact: unsupported components must escalate or no-op safely instead of pretending delivery support exists.
-
-### DEC-SIN-16
 - decision: the repository remains public until further notice while `main` stays protected as the truth branch.
 - rationale: low-cost operation is currently preferred over private-repo administration while protected `main` still preserves truth discipline.
 - impact: work happens in public branches and PRs; accepted truth still gates on protected `main`.
-
-### DEC-SIN-17
 - decision: system integration uses short-lived repo-control-plane branches to `main` by default; `integration/staging` is exception-only.
 - rationale: this minimizes branch clutter, truth ambiguity, and owner click overhead.
 - impact: SI changes should normally ship as packaged PRs from temporary branches.
-
-### DEC-SIN-18
 - decision: when tooling, connector, access, or execution problems block safe completion, agents must escalate and inform instead of improvising, faking completion, or silently creating partial truth.
 - rationale: false completion is more dangerous than an explicit blocker in a governed repo.
 - impact: blocking technical issues become visible repo/integration risks instead of hidden drift.
-
-### DEC-SIN-19
 - decision: if the connector cannot safely mutate an existing protected truth file, the controlled replacement-file operating model is the standard exception path.
 - rationale: protected truth must remain accurate even when the mutation surface is limited.
 - impact: replacement artifacts such as `ag_new.txt` are allowed as an exception path when clearly documented.
-
-### DEC-SIN-20
 - decision: one target Pi may have only one active deploy/test slot at a time; no other deploy may run while that slot is occupied.
 - rationale: parallel deploys destroy test validity and make rollback anchors ambiguous.
 - impact: deploy/test/rollback workflows must respect target-slot state such as `free`, `deploying`, `test_open`, `rollback_running`, and `blocked`.
-
-### DEC-SIN-21
 - decision: SI/governance work must follow a dedicated branch path `si/<topic>` from local implementation to pushed branch and PR to protected `main`.
 - rationale: branch clarity is required for autonomous governance discipline and avoids drift from generic local branch names.
 - impact: SI lane execution, onboarding, and PR preparation now require explicit SI branch naming and same-branch promotion to `main`.
-
-### DEC-SIN-22
 - decision: SI onboarding preflight must explicitly reject branch name `work` for SI truth changes and must verify remote `git` points to `https://github.com/SH99999/mediastreamer.git` before push/PR handoff.
 - rationale: avoids ambiguous local execution and prevents pushes to the wrong remote.
 - impact: replacement SI agents must run branch+remote preflight checks before packaging governed SI changes.
-
-### DEC-SIN-23
 - decision: stage-B UI/UX autonomy requires proposal-reference fields and decision options in intake issues, plus `decision_output_v1` as canonical owner decision output block.
 - rationale: repeated UI/UX iterations need deterministic automation anchors and low-click owner decision handling.
 - impact: issue templates and onboarding now require proposal URI/revision and decision options; project view setup follows the in-repo blueprint.
-
-### DEC-SIN-25
 - decision: status prompts are fulfilled via generated repo pages under `reports/status/` with clickable source links and compact visual summaries.
 - rationale: reduces owner and agent overhead for recurring status requests and keeps outputs anchored to Git truth.
 - impact: status handling for `status tuner|governance|ui|bridge|decisions|blocker` now maps to generated markdown artifacts.
-## 5. Open Decisions
+
+## Open decision blockers
 - when additional components beyond bridge, tuner, and fun-line become delivery-capable in the autonomous support matrix
 - whether the repository should later move to private visibility if the cost/risk tradeoff changes
 - whether low-risk PR classes should later auto-merge once the current packaged-review model has matured further
 - whether project view creation for `Scale Radio Governance & Delivery` should be executed by API automation or owner one-time manual apply from the canonical blueprint
 
-## 6. Runtime / Deployment Notes
-- current validated deploy/rollback reference components:
-  - Bridge
-  - Tuner overlay/runtime/service lane
-- next manual validation target with repo deploy lane ready:
-  - Fun Line overlay lane (`current`)
-- delivery support matrix on `main` now supports Bridge, Tuner, and Fun Line for autonomous dispatch
-- autonomous deploy line remains partial at repository scope because other components are still unsupported
-- owner remains the final onsite acceptance gate before stable truth is merged to `main`
-- source-project artifacts remain temporarily out of deploy-lane scope and are controlled via hardware interaction rules (encoder short/long press) until full integration
+## Source
+- [SI status](/workspace/mediastreamer/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md)
 
-## 7. Next Recommended Steps
-1. normalize the separate `radio_scale_source` artifact if tuner must again ship both overlay and source as one governed lane
-2. normalize the next component wrapper contract after bridge and tuner
-3. keep source-project scope boundaries explicit (hardware-governed until full integration)
-4. standardize immutable payload naming and governed pointer resolution across deployable components
+## Visual snapshot
+```mermaid
+pie
+    title Blocker buckets
+    "broken" : 54
+    "open decisions" : 4
+```

--- a/reports/status/bridge.md
+++ b/reports/status/bridge.md
@@ -1,6 +1,6 @@
 # Status Bridge
 
-_Generated: 2026-04-16T06:17:21.920809+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Quick summary
 - `payload_complete`

--- a/reports/status/bridge.md
+++ b/reports/status/bridge.md
@@ -1,0 +1,31 @@
+# Status Bridge
+
+_Generated: 2026-04-16T06:17:21.920809+00:00_
+
+## Quick summary
+- `payload_complete`
+- `deployment_candidate_started`
+- `deploy_ready`
+- `tested_on_pi`
+- `functional_acceptance_open`
+
+## Main open points
+- lyrics sync quality is still the main unresolved functional weakness
+- long-run validation of `bridge_cache.sqlite` and cache reuse is still pending
+- broader Spotify redesign remains intentionally frozen pending credential/API-key clarification
+- current branch remains a dev lane and is not yet promoted as the accepted `main` artifact truth
+
+## Next actions
+
+## Sources
+- [Current state](/workspace/mediastreamer/journals/scale-radio-bridge/current_state_v1.md)
+- [Stream](/workspace/mediastreamer/journals/scale-radio-bridge/stream_v1.md)
+
+## Visual snapshot
+```mermaid
+pie
+    title Lifecycle snapshot
+    "lifecycle entries" : 5
+    "main gaps" : 4
+    "next actions" : 0
+```

--- a/reports/status/decisions.md
+++ b/reports/status/decisions.md
@@ -1,6 +1,6 @@
 # Status Decisions
 
-_Generated: 2026-04-16T06:17:21.921443+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Quick summary
 - total decision entries: 19

--- a/reports/status/decisions.md
+++ b/reports/status/decisions.md
@@ -1,0 +1,29 @@
+# Status Decisions
+
+_Generated: 2026-04-16T06:17:21.921443+00:00_
+
+## Quick summary
+- total decision entries: 19
+- locked decisions: 19
+
+## Recent decision IDs
+- DEC-system_integration_normalization-24
+- DEC-system_integration_normalization-25
+- DEC-system_integration_normalization-26
+- DEC-system_integration_normalization-27
+- DEC-system_integration_normalization-28
+- DEC-system_integration_normalization-29
+- DEC-system_integration_normalization-30
+- DEC-system_integration_normalization-32
+
+## Source
+- [SI decisions](/workspace/mediastreamer/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md)
+
+## Visual snapshot
+```mermaid
+xychart-beta
+    title "Decisions"
+    x-axis ["total", "locked"]
+    y-axis "Count" 0 --> 19
+    bar [19, 19]
+```

--- a/reports/status/governance.md
+++ b/reports/status/governance.md
@@ -1,6 +1,6 @@
 # Status Governance
 
-_Generated: 2026-04-16T06:17:21.920370+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Quick summary
 - governance, issue-routing, and reporting workflows exist on `main`

--- a/reports/status/governance.md
+++ b/reports/status/governance.md
@@ -1,0 +1,31 @@
+# Status Governance
+
+_Generated: 2026-04-16T06:17:21.920370+00:00_
+
+## Quick summary
+- governance, issue-routing, and reporting workflows exist on `main`
+- one-click branch rebase exists for all current and future `dev/*` and `integration/*` branches
+- weekly governance report issues are generated from repo truth
+- open decisions, branch drift, and journal freshness can become governance-routed issues automatically
+- PR governance review and governance closeout workflows are active
+- new governed components can be bootstrapped via workflow
+
+## Partial
+- autonomous delivery remains support-matrix gated, now including Bridge, Tuner, and Fun Line while other components remain unsupported
+- top-level truth-file mutation through the current connector surface remains limited, so replacement artifacts may still be required in some cases
+- tuner deploy normalization is intentionally scoped to overlay/runtime/service while source-selection behavior remains hardware-governed (encoder short/long press) until full integration
+
+## Blockers
+- unsupported components still cannot use autonomous delivery and must still escalate or no-op safely
+
+## Sources
+- [SI status](/workspace/mediastreamer/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md)
+
+## Visual snapshot
+```mermaid
+xychart-beta
+    title "Governance health buckets"
+    x-axis ["works", "partial", "broken"]
+    y-axis "Count" 0 --> 17
+    bar [13, 3, 1]
+```

--- a/reports/status/index.md
+++ b/reports/status/index.md
@@ -1,6 +1,6 @@
 # Status Reports Index v1
 
-_Generated: 2026-04-16T06:17:21.923349+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 Prompt aliases:
 - `status tuner` -> [Status Tuner](./tuner.md)

--- a/reports/status/index.md
+++ b/reports/status/index.md
@@ -1,0 +1,13 @@
+# Status Reports Index v1
+
+_Generated: 2026-04-16T06:17:21.923349+00:00_
+
+Prompt aliases:
+- `status tuner` -> [Status Tuner](./tuner.md)
+- `status governance` -> [Status Governance](./governance.md)
+- `status ui` -> [Status UI](./ui.md)
+- `status bridge` -> [Status Bridge](./bridge.md)
+- `status decisions` -> [Status Decisions](./decisions.md)
+- `status blocker` -> [Status Blocker](./blocker.md)
+
+Data sources are repository files so prompts can be handled from Git truth.

--- a/reports/status/tuner.md
+++ b/reports/status/tuner.md
@@ -1,6 +1,6 @@
 # Status Tuner
 
-_Generated: 2026-04-16T06:17:21.919926+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Quick summary
 - `payload_complete`

--- a/reports/status/tuner.md
+++ b/reports/status/tuner.md
@@ -1,0 +1,32 @@
+# Status Tuner
+
+_Generated: 2026-04-16T06:17:21.919926+00:00_
+
+## Quick summary
+- `payload_complete`
+- `deployment_candidate_started`
+- `deploy_ready`
+- `deploy_validated_on_pi`
+- `rollback_validated_on_pi`
+- `manual_runtime_validation_passed`
+
+## Main open points
+- the currently normalized deploy lane intentionally covers the overlay and resident renderer service only
+- `radio_scale_source` remains out of deploy-lane scope until full integration and is currently governed by hardware controls (encoder short/long press)
+- first-show pointer sweep after boot remains unresolved
+- exit white flashes remain unresolved
+
+## Next actions
+
+## Sources
+- [Current state](/workspace/mediastreamer/journals/scale-radio-tuner/current_state_v2.md)
+- [Stream](/workspace/mediastreamer/journals/scale-radio-tuner/stream_v2.md)
+
+## Visual snapshot
+```mermaid
+pie
+    title Lifecycle snapshot
+    "lifecycle entries" : 6
+    "main gaps" : 4
+    "next actions" : 0
+```

--- a/reports/status/ui.md
+++ b/reports/status/ui.md
@@ -1,6 +1,6 @@
 # Status UI
 
-_Generated: 2026-04-16T06:17:21.920597+00:00_
+_Generated: 2026-04-16T07:01:14.957359+00:00_
 
 ## Recent governance entries
 - 2026-04-15: Rule recorded that UI/GUI governance entries here must be mirrored by component journals when runtime/deploy behavior changes in a component.

--- a/reports/status/ui.md
+++ b/reports/status/ui.md
@@ -1,0 +1,22 @@
+# Status UI
+
+_Generated: 2026-04-16T06:17:21.920597+00:00_
+
+## Recent governance entries
+- 2026-04-15: Rule recorded that UI/GUI governance entries here must be mirrored by component journals when runtime/deploy behavior changes in a component.
+- 2026-04-15: Transitional decision recorded that the current GUI concept is sufficient until full integration is explicitly opened under SI governance.
+- 2026-04-15: Stage-B autonomy contract added for UI/UX proposal-reference intake and owner `decision_output_v1` packet output.
+- 2026-04-15: Project-view blueprint path added (`tools/governance/scale_radio_governance_delivery_views_v1.md`) for owner decision readiness in `Scale Radio Governance & Delivery`.
+- 2026-04-15: Table and kanban markdown renderings added for project-view blueprint to improve owner-facing review in Git (`..._views_table_v1.md`, `..._views_kanban_v1.md`).
+- 2026-04-15: Project-view triage definition was generalized to component-wide intake routing; UI/GUI remains in-scope via `agent:ux` and no longer assumes UI-only queue boundaries.
+
+## Source
+- [UI/GUI stream](/workspace/mediastreamer/journals/system-integration-normalization/ui_gui_stream_v1.md)
+
+## Visual snapshot
+```mermaid
+pie
+    title UI governance stream
+    "entries sampled" : 6
+    "total entries" : 17
+```

--- a/tools/governance/generate_status_reports_v1.py
+++ b/tools/governance/generate_status_reports_v1.py
@@ -21,21 +21,21 @@ def read(path: Path) -> str:
 
 def section_bullets(text: str, heading: str) -> list[str]:
     lines = text.splitlines()
-    out = []
+    out: list[str] = []
     capture = False
     heading_prefix = f"## {heading}"
     for line in lines:
-      if line.startswith("## ") and line.strip() == heading_prefix:
-        capture = True
-        continue
-      if capture and line.startswith("## "):
-        break
-      if capture and line.lstrip().startswith("-"):
-        out.append(line.lstrip()[1:].strip())
+        if line.startswith("## ") and line.strip() == heading_prefix:
+            capture = True
+            continue
+        if capture and line.startswith("## "):
+            break
+        if capture and line.lstrip().startswith("-"):
+            out.append(line.lstrip()[1:].strip())
     return out
 
 
-def status_from_component(component: str, current_state_path: Path, stream_path: Path) -> Report:
+def status_from_component(component: str, current_state_path: Path, stream_path: Path, generated_at: str) -> Report:
     cs = read(current_state_path)
     lifecycle = section_bullets(cs, "Lifecycle status")[:6]
     gaps = section_bullets(cs, "Current gaps")[:4]
@@ -44,7 +44,7 @@ def status_from_component(component: str, current_state_path: Path, stream_path:
     body = "\n".join([
         f"# Status {component}",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "## Quick summary",
         *(f"- {i}" for i in lifecycle),
@@ -72,7 +72,7 @@ def status_from_component(component: str, current_state_path: Path, stream_path:
     return Report(component.lower(), f"Status {component}", body)
 
 
-def governance_status_report(si_status_path: Path) -> Report:
+def governance_status_report(si_status_path: Path, generated_at: str) -> Report:
     text = read(si_status_path)
     works = []
     partial = []
@@ -103,7 +103,7 @@ def governance_status_report(si_status_path: Path) -> Report:
     body = "\n".join([
         "# Status Governance",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "## Quick summary",
         *(f"- {w}" for w in works[:6]),
@@ -130,14 +130,14 @@ def governance_status_report(si_status_path: Path) -> Report:
     return Report("governance", "Status Governance", body)
 
 
-def ui_status_report(ui_stream_path: Path) -> Report:
+def ui_status_report(ui_stream_path: Path, generated_at: str) -> Report:
     text = read(ui_stream_path)
     entries = [ln.strip()[2:].strip() for ln in text.splitlines() if ln.strip().startswith("-")]
     recent = entries[-6:]
     body = "\n".join([
         "# Status UI",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "## Recent governance entries",
         *(f"- {r}" for r in recent),
@@ -157,14 +157,14 @@ def ui_status_report(ui_stream_path: Path) -> Report:
     return Report("ui", "Status UI", body)
 
 
-def decisions_report(decisions_path: Path) -> Report:
+def decisions_report(decisions_path: Path, generated_at: str) -> Report:
     text = read(decisions_path)
     ids = re.findall(r"^###\s+(DEC-[^\n]+)", text, flags=re.MULTILINE)
     locked = len(re.findall(r"^- Status:\s*locked", text, flags=re.MULTILINE))
     body = "\n".join([
         "# Status Decisions",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "## Quick summary",
         f"- total decision entries: {len(ids)}",
@@ -189,7 +189,7 @@ def decisions_report(decisions_path: Path) -> Report:
     return Report("decisions", "Status Decisions", body)
 
 
-def blocker_report(si_status_path: Path) -> Report:
+def blocker_report(si_status_path: Path, generated_at: str) -> Report:
     text = read(si_status_path)
     broken = []
     open_decisions = []
@@ -212,7 +212,7 @@ def blocker_report(si_status_path: Path) -> Report:
     body = "\n".join([
         "# Status Blocker",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "## Active broken points",
         *(f"- {b}" for b in broken),
@@ -244,27 +244,35 @@ def main():
     parser = argparse.ArgumentParser(description="Generate prompt-ready status reports with clickable links and visuals.")
     parser.add_argument("--repo-root", default=".", help="Repository root path")
     parser.add_argument("--out-dir", default="reports/status", help="Output directory for generated markdown reports")
+    parser.add_argument(
+        "--generated-at",
+        default=None,
+        help="Optional ISO8601 timestamp to stamp all generated reports deterministically",
+    )
     args = parser.parse_args()
 
     root = Path(args.repo_root).resolve()
     out = root / args.out_dir
     out.mkdir(parents=True, exist_ok=True)
+    generated_at = args.generated_at or datetime.now(timezone.utc).isoformat()
 
     reports = [
         status_from_component(
             "Tuner",
             root / "journals/scale-radio-tuner/current_state_v2.md",
             root / "journals/scale-radio-tuner/stream_v2.md",
+            generated_at,
         ),
-        governance_status_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md"),
-        ui_status_report(root / "journals/system-integration-normalization/ui_gui_stream_v1.md"),
+        governance_status_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md", generated_at),
+        ui_status_report(root / "journals/system-integration-normalization/ui_gui_stream_v1.md", generated_at),
         status_from_component(
             "Bridge",
             root / "journals/scale-radio-bridge/current_state_v1.md",
             root / "journals/scale-radio-bridge/stream_v1.md",
+            generated_at,
         ),
-        decisions_report(root / "journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md"),
-        blocker_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md"),
+        decisions_report(root / "journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md", generated_at),
+        blocker_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md", generated_at),
     ]
 
     for r in reports:
@@ -273,7 +281,7 @@ def main():
     index_lines = [
         "# Status Reports Index v1",
         "",
-        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        f"_Generated: {generated_at}_",
         "",
         "Prompt aliases:",
         "- `status tuner` -> [Status Tuner](./tuner.md)",

--- a/tools/governance/generate_status_reports_v1.py
+++ b/tools/governance/generate_status_reports_v1.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+
+@dataclass
+class Report:
+    slug: str
+    title: str
+    body: str
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def section_bullets(text: str, heading: str) -> list[str]:
+    lines = text.splitlines()
+    out = []
+    capture = False
+    heading_prefix = f"## {heading}"
+    for line in lines:
+      if line.startswith("## ") and line.strip() == heading_prefix:
+        capture = True
+        continue
+      if capture and line.startswith("## "):
+        break
+      if capture and line.lstrip().startswith("-"):
+        out.append(line.lstrip()[1:].strip())
+    return out
+
+
+def status_from_component(component: str, current_state_path: Path, stream_path: Path) -> Report:
+    cs = read(current_state_path)
+    lifecycle = section_bullets(cs, "Lifecycle status")[:6]
+    gaps = section_bullets(cs, "Current gaps")[:4]
+    next_actions = section_bullets(cs, "Repo-normalized next action")[:3]
+
+    body = "\n".join([
+        f"# Status {component}",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "## Quick summary",
+        *(f"- {i}" for i in lifecycle),
+        "",
+        "## Main open points",
+        *(f"- {i}" for i in gaps),
+        "",
+        "## Next actions",
+        *(f"- {i}" for i in next_actions),
+        "",
+        "## Sources",
+        f"- [Current state]({current_state_path.as_posix()})",
+        f"- [Stream]({stream_path.as_posix()})",
+        "",
+        "## Visual snapshot",
+        "```mermaid",
+        "pie",
+        "    title Lifecycle snapshot",
+        f"    \"lifecycle entries\" : {len(lifecycle)}",
+        f"    \"main gaps\" : {len(gaps)}",
+        f"    \"next actions\" : {len(next_actions)}",
+        "```",
+        "",
+    ])
+    return Report(component.lower(), f"Status {component}", body)
+
+
+def governance_status_report(si_status_path: Path) -> Report:
+    text = read(si_status_path)
+    works = []
+    partial = []
+    broken = []
+    mode = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("- what currently works:"):
+            mode = "works"
+            continue
+        if s.startswith("- what partially works:"):
+            mode = "partial"
+            continue
+        if s.startswith("- what is broken:"):
+            mode = "broken"
+            continue
+        if s.startswith("- what was tested:"):
+            mode = None
+        if mode and s.startswith("-"):
+            value = s[1:].strip()
+            if mode == "works":
+                works.append(value)
+            elif mode == "partial":
+                partial.append(value)
+            elif mode == "broken":
+                broken.append(value)
+
+    body = "\n".join([
+        "# Status Governance",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "## Quick summary",
+        *(f"- {w}" for w in works[:6]),
+        "",
+        "## Partial",
+        *(f"- {p}" for p in partial[:4]),
+        "",
+        "## Blockers",
+        *(f"- {b}" for b in broken[:4]),
+        "",
+        "## Sources",
+        f"- [SI status]({si_status_path.as_posix()})",
+        "",
+        "## Visual snapshot",
+        "```mermaid",
+        "xychart-beta",
+        "    title \"Governance health buckets\"",
+        "    x-axis [\"works\", \"partial\", \"broken\"]",
+        f"    y-axis \"Count\" 0 --> {max(3, len(works)+len(partial)+len(broken))}",
+        f"    bar [{len(works)}, {len(partial)}, {len(broken)}]",
+        "```",
+        "",
+    ])
+    return Report("governance", "Status Governance", body)
+
+
+def ui_status_report(ui_stream_path: Path) -> Report:
+    text = read(ui_stream_path)
+    entries = [ln.strip()[2:].strip() for ln in text.splitlines() if ln.strip().startswith("-")]
+    recent = entries[-6:]
+    body = "\n".join([
+        "# Status UI",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "## Recent governance entries",
+        *(f"- {r}" for r in recent),
+        "",
+        "## Source",
+        f"- [UI/GUI stream]({ui_stream_path.as_posix()})",
+        "",
+        "## Visual snapshot",
+        "```mermaid",
+        "pie",
+        "    title UI governance stream",
+        f"    \"entries sampled\" : {len(recent)}",
+        f"    \"total entries\" : {len(entries)}",
+        "```",
+        "",
+    ])
+    return Report("ui", "Status UI", body)
+
+
+def decisions_report(decisions_path: Path) -> Report:
+    text = read(decisions_path)
+    ids = re.findall(r"^###\s+(DEC-[^\n]+)", text, flags=re.MULTILINE)
+    locked = len(re.findall(r"^- Status:\s*locked", text, flags=re.MULTILINE))
+    body = "\n".join([
+        "# Status Decisions",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "## Quick summary",
+        f"- total decision entries: {len(ids)}",
+        f"- locked decisions: {locked}",
+        "",
+        "## Recent decision IDs",
+        *(f"- {d}" for d in ids[-8:]),
+        "",
+        "## Source",
+        f"- [SI decisions]({decisions_path.as_posix()})",
+        "",
+        "## Visual snapshot",
+        "```mermaid",
+        "xychart-beta",
+        "    title \"Decisions\"",
+        "    x-axis [\"total\", \"locked\"]",
+        f"    y-axis \"Count\" 0 --> {max(5, len(ids))}",
+        f"    bar [{len(ids)}, {locked}]",
+        "```",
+        "",
+    ])
+    return Report("decisions", "Status Decisions", body)
+
+
+def blocker_report(si_status_path: Path) -> Report:
+    text = read(si_status_path)
+    broken = []
+    open_decisions = []
+    mode = None
+    for line in text.splitlines():
+        s = line.strip()
+        if s.startswith("- what is broken:"):
+            mode = "broken"
+            continue
+        if s.startswith("## 5. Open Decisions"):
+            mode = "open"
+            continue
+        if s.startswith("## 6."):
+            mode = None
+        if mode == "broken" and s.startswith("-"):
+            broken.append(s[1:].strip())
+        if mode == "open" and s.startswith("-"):
+            open_decisions.append(s[1:].strip())
+
+    body = "\n".join([
+        "# Status Blocker",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "## Active broken points",
+        *(f"- {b}" for b in broken),
+        "",
+        "## Open decision blockers",
+        *(f"- {o}" for o in open_decisions),
+        "",
+        "## Source",
+        f"- [SI status]({si_status_path.as_posix()})",
+        "",
+        "## Visual snapshot",
+        "```mermaid",
+        "pie",
+        "    title Blocker buckets",
+        f"    \"broken\" : {len(broken)}",
+        f"    \"open decisions\" : {len(open_decisions)}",
+        "```",
+        "",
+    ])
+    return Report("blocker", "Status Blocker", body)
+
+
+def write_report(base: Path, report: Report):
+    path = base / f"{report.slug}.md"
+    path.write_text(report.body, encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate prompt-ready status reports with clickable links and visuals.")
+    parser.add_argument("--repo-root", default=".", help="Repository root path")
+    parser.add_argument("--out-dir", default="reports/status", help="Output directory for generated markdown reports")
+    args = parser.parse_args()
+
+    root = Path(args.repo_root).resolve()
+    out = root / args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+
+    reports = [
+        status_from_component(
+            "Tuner",
+            root / "journals/scale-radio-tuner/current_state_v2.md",
+            root / "journals/scale-radio-tuner/stream_v2.md",
+        ),
+        governance_status_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md"),
+        ui_status_report(root / "journals/system-integration-normalization/ui_gui_stream_v1.md"),
+        status_from_component(
+            "Bridge",
+            root / "journals/scale-radio-bridge/current_state_v1.md",
+            root / "journals/scale-radio-bridge/stream_v1.md",
+        ),
+        decisions_report(root / "journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md"),
+        blocker_report(root / "journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md"),
+    ]
+
+    for r in reports:
+        write_report(out, r)
+
+    index_lines = [
+        "# Status Reports Index v1",
+        "",
+        f"_Generated: {datetime.now(timezone.utc).isoformat()}_",
+        "",
+        "Prompt aliases:",
+        "- `status tuner` -> [Status Tuner](./tuner.md)",
+        "- `status governance` -> [Status Governance](./governance.md)",
+        "- `status ui` -> [Status UI](./ui.md)",
+        "- `status bridge` -> [Status Bridge](./bridge.md)",
+        "- `status decisions` -> [Status Decisions](./decisions.md)",
+        "- `status blocker` -> [Status Blocker](./blocker.md)",
+        "",
+        "Data sources are repository files so prompts can be handled from Git truth.",
+    ]
+    (out / "index.md").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
+    print(f"generated_reports={len(reports)}")
+    print(f"output={out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- stabilize status report generator timestamps and formatting
- add owner-facing PR merge sequence and rollback playbook with topic links
- keep SI/governance flow on dedicated si/<topic> branch to main

## Why
- owner requested a clear, safe sequence for PR merges into main without governance drift
- rollback must remain explicit and operational for both runtime and repo truth decisions

## Validation
- python3 -m py_compile tools/governance/generate_status_reports_v1.py
- python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status
- bash -n tools/governance/agent_git_bootstrap_v1.sh tools/governance/container_startup_setup_v1.sh tools/deploy/sr-deploy-wrapper-v2.sh tools/deploy/sr-deploy-wrapper-v3.sh components/scale-radio-fun-line/deploy_candidates/apply_payload_v1.sh components/scale-radio-fun-line/deploy_candidates/healthcheck_runtime_v1.sh components/scale-radio-fun-line/deploy_candidates/remove_active_v1.sh