### PR TITLE
feat(bootstrap): role-aware mode-B startup + compact audit response chain

### DIFF
--- a/docs/agents/audit_response_compact_chain_v1.md
+++ b/docs/agents/audit_response_compact_chain_v1.md
@@ -1,0 +1,80 @@
+# AUDIT RESPONSE — COMPACT CHAIN V1
+
+## Purpose
+Provide a minimal, structured response format for ChatGPT handoff on the 2026-04-16 governance audit.
+
+---
+
+## 1) Decision baseline (no narrative)
+- Audit verdict accepted: **yes**
+- Primary problem class: **governance consolidation deficit**
+- Not primary problem: **missing governance model**
+
+---
+
+## 2) Top issues to address (ranked, essential only)
+1. **Document generation sprawl** (active vs historical not hard-separated)
+2. **Onboarding read-load** (safe but too heavy)
+3. **Delivery normalization not repo-wide yet**
+4. **One-click term overloaded** (owner governance click vs component delivery click)
+
+---
+
+## 3) Scope split (must stay explicit)
+### A. Owner one-click governance
+- Status: **operational**
+- Path: decision-ready packet -> checks green -> owner merge decision
+
+### B. Component delivery one-click
+- Status: **partial**
+- Constraint: support-matrix and component-specific readiness
+
+---
+
+## 4) Mandatory outcomes by phase
+### Phase 1 — truth-chain consolidation
+- mark one **Primary Active Chain**
+- move older SI onboarding/index generations behind archive/superseded index
+- block new references to superseded generations in CI
+- define and publish bootstrap minimum chain
+
+### Phase 2 — delivery normalization
+- run per-component gap check vs deploy process standard
+- make explicit decision for tuner split vs full lane normalization
+- update support matrix only with matching journal/decision/evidence updates
+
+### Phase 3 — one-click precision
+- keep two distinct terms:
+  - owner one-click governance
+  - component delivery one-click
+- keep fallback path documented but non-default
+
+---
+
+## 5) Hard rules (do not relax)
+- `main` stays protected truth
+- SI/governance mutations stay on `si/<topic>`
+- owner role stays decision/merge authority; PR mechanics remain agent-lane work
+- truthful blocker reporting over implied completion
+
+---
+
+## 6) Copy/paste response block for ChatGPT (short)
+```text
+Audit response (compact):
+1) Accepted: governance model is viable; main gap is consolidation.
+2) Immediate priority: active-vs-historical chain hard separation + CI anti-reference guard.
+3) Onboarding: keep mode-B safe-start; enforce escalation triggers to full chain.
+4) One-click: separate owner-governance click from component-delivery click in all docs.
+5) Delivery: run component gap checks and update support matrix only with evidence-linked journal/decision updates.
+```
+
+---
+
+## 7) Owner-ready decision block (optional)
+```text
+decision: accept
+scope: governance consolidation phase 1
+mandatory follow-up: hard-separate active vs historical chain and enforce CI anti-reference guard
+merge authorization: yes
+```

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -341,3 +341,7 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 - updated bootstrap output to point first to the reference map and second to role profiles
 - updated role profiles to consume shared deferred references via reference map, reducing repeated cross-links in each role section
 - purpose: keep mode-B fast while reducing documentation maintenance overhead and preserving deterministic escalation paths
+
+### 2026-04-16 / si/bootstrap-role-mode-b-v1 / compact audit-response chain for low-read owner handoff
+- added `docs/agents/audit_response_compact_chain_v1.md` with essential-only, ranked issues, phase outcomes, hard rules, and copy/paste handoff blocks
+- purpose: provide low-read structured responses for ChatGPT roundtrips without narrative overhead


### PR DESCRIPTION
## Summary
- add role-aware bootstrap mode-B output (`--role`, `--mode`) with deferred packet pointers
- add single-source deferred reference map for role bootstrap
- add compact audit response chain markdown for low-read ChatGPT handoff
- update SI stream journal entries for bootstrap and audit-response artifacts

## Validation
- bash -n tools/governance/agent_git_bootstrap_v1.sh
- bash tools/governance/agent_git_bootstrap_v1.sh --branch si/bootstrap-role-mode-b-v1 --role si --mode mode-b
- git diff --check
