### PR TITLE
Standardize label-indexed owner repo-truth query surface and execution-gate labels

### DIFF
--- a/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
+++ b/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
@@ -120,6 +120,16 @@ Every relevant demand/idea item must be classified as:
 - `execution_gate: quick_win`
 - `execution_gate: backlog`
 
+Label index mapping (mandatory for queryability):
+- `execution_gate: now` -> `gate:now`
+- `execution_gate: quick_win` -> `gate:quick-win`
+- `execution_gate: backlog` -> `gate:backlog`
+
+Index-vs-truth rule:
+- labels are the query index
+- repo artifacts remain canonical truth for summary/decisions/risks/non-loss requirements/related outputs
+- if label index and repo artifact disagree, repo artifact wins and mismatch must be corrected
+
 Required companion fields:
 - `why_now`
 - `why_not_now`
@@ -201,6 +211,39 @@ Backlog items must preserve:
 - related files/outputs/links
 - why_not_now
 - promotion_trigger
+
+## Owner repo-truth query contract (canonical)
+ChatGPT owner-query classes (minimum required):
+- backlog
+- ideas
+- blockers
+- decisions awaiting owner
+- quick wins
+- component-filtered view for any class
+
+Query index labels:
+- backlog: `gate:backlog`
+- ideas: `type:idea` (or idea artifact under `exchange/chatgpt/ideas/`) + optional `gate:*`
+- blockers: `state:blocked`
+- decisions awaiting owner: `state:needs-decision` or `state:awaiting-owner`
+- quick wins: `gate:quick-win`
+- component filter: append `component:<x>` and/or artifact path filter
+
+Repo artifacts to inspect:
+- `exchange/chatgpt/demands/*.md`
+- `exchange/chatgpt/ideas/*.md`
+- `journals/**/current_state*.md` and `journals/**/stream*.md`
+- decision/status contracts and SI current status/decisions/stream
+
+ChatGPT response format for owner queries:
+1. short structured summary
+2. direct Git object links (tree/blob/commit paths)
+3. optional GitHub label-filter URL
+4. explicit owner todo or `no action needed`
+
+Link-first rule:
+- prefer native GitHub object links and label filter URLs
+- do not require HTML/dashboard aggregation for this query surface
 
 ## Durable truth update obligation
 Execution packages must update durable repo truth when impacted:

--- a/contracts/repo/issue_governance_routing_standard_v1.md
+++ b/contracts/repo/issue_governance_routing_standard_v1.md
@@ -65,6 +65,21 @@ Reason:
 - `state:docs-update-required`
 - `state:done`
 
+### Execution-gate labels (owner-query index)
+- `gate:now`
+- `gate:quick-win`
+- `gate:backlog`
+
+Execution-gate meaning:
+- `gate:now` = currently authorized execution scope
+- `gate:quick-win` = low-blast-radius candidate that Codex may attach only when safety/coherence rules pass
+- `gate:backlog` = preserved future candidate; never silently executed only because it exists
+
+Execution-gate governance rule:
+- labels classify/route/query
+- detailed truth remains in repo artifacts (demand/idea/status/current-state/decision files)
+- if labels and repo truth disagree, repo truth wins and mismatch is a repo-truth defect
+
 ### Source labels
 - `source:weekly-report`
 - `source:decision-scan`
@@ -78,6 +93,7 @@ Reason:
 - `impact:cross-component` should also carry `agent:system-integration`
 - `component:<x>` with only component-local impact should carry `agent:<x>`
 - `type:decision` should carry `state:needs-decision`
+- owner-query execution inventory should include one of `gate:now|gate:quick-win|gate:backlog` where applicable
 - after owner decision, switch to `state:docs-update-required`
 - after governance updates are merged, switch to `state:done`
 

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -62,6 +62,8 @@ Tier-2 deep-history references are read-only and listed in:
 - ChatGPT exchange for audit/demand loops should use the governed exchange root `exchange/chatgpt/` with inbox/outbox artifact flow
 - Chat-to-demand continuity is mandatory: relevant chat outcomes must be captured to `exchange/chatgpt/sessions/` within 5 minutes, then promoted to `exchange/chatgpt/demands/` at owner command `ship to codex` (internal `chatok`)
 - Chat execution-gate classification is mandatory for demand/idea items: `now | quick_win | backlog` with promotion rationale and related outputs preserved in repo truth
+- execution-gate labels are standardized for owner query/indexing: `gate:now`, `gate:quick-win`, `gate:backlog`
+- owner repo-truth queries should be answerable from labels + canonical repo artifacts with direct Git links (no custom-field dependency required)
 - agent status reporting should emit `status_packet_v1` payloads and render markdown from packet data for owner-facing views
 - `next_owner_click` should be present in all generated status views and validated by enforcement checks
 - decision scoring fields and rollback one-click action contract should be present in decision/status packets (`evidence_quality`, `rollback_readiness`, `blast_radius`, `confidence`, `rollback_action`)

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -140,6 +140,32 @@ Generated pages:
 - [Status bridge](../../reports/status/bridge.md)
 - [Status decisions](../../reports/status/decisions.md)
 - [Status blocker](../../reports/status/blocker.md)
+
+## Repo-truth owner query surface (label-index + Git-truth)
+Use this prompt style in ChatGPT:
+- `repo truth: what is in backlog`
+- `repo truth: open blockers`
+- `repo truth: decisions awaiting owner`
+- `repo truth: quick wins for tuner`
+- `repo truth: ideas already defined for fun-line`
+
+Query/index rule:
+- labels are the query index
+- repo artifacts are the truth
+- if labels disagree with repo artifacts, repo artifacts win and mismatch should be treated as a repo-truth defect
+
+Expected ChatGPT answer format:
+1. short structured summary
+2. direct Git links to the referenced files/commits
+3. optional GitHub label-filter URL
+4. explicit owner todo or `no action needed`
+
+Canonical query labels:
+- `gate:backlog` (backlog)
+- `gate:quick-win` (quick wins)
+- `state:blocked` (blockers)
+- `state:needs-decision` / `state:awaiting-owner` (decisions awaiting owner)
+- `component:<x>` (component filter)
 ## Current recurring setup topics to monitor
 - runtime token injection drift (`GH_TOKEN` / `GITHUB_TOKEN` not visible in active runtime session)
 - branch discipline drift (agent starts on `work` instead of `dev/*` or `si/*`)

--- a/exchange/chatgpt/PROTOCOL_v1.md
+++ b/exchange/chatgpt/PROTOCOL_v1.md
@@ -47,6 +47,7 @@ Minimum persistence layer before full durable truth updates:
 ## Execution gate rule
 Relevant demand/idea items must carry:
 - `execution_gate: now|quick_win|backlog`
+- `execution_gate_label: gate:now|gate:quick-win|gate:backlog`
 - `why_now`
 - `why_not_now`
 - `promotion_trigger`
@@ -57,6 +58,10 @@ Routing:
 - `now` -> active demand execution
 - `quick_win` -> Codex may attach if safe and coherent
 - `backlog` -> preserved/visible; not silently executed
+
+Index-vs-truth:
+- labels are index/routing/query
+- repo artifacts are canonical detailed truth
 
 ## Promotion rule (`chatok`)
 - promotion source: `exchange/chatgpt/sessions/<topic>__live_v1.md`

--- a/exchange/chatgpt/demands/README.md
+++ b/exchange/chatgpt/demands/README.md
@@ -16,6 +16,7 @@ Use `TEMPLATE__intake_v1.md` and keep all required sections:
 - execution request for Codex
 - status marker
 - execution gate fields (`execution_gate`, `why_now`, `why_not_now`, `promotion_trigger`, `safe_to_attach_to_current_package`, `related_files_outputs`, `impacted_portfolio_component`)
+- label index block (`expected_labels`, `label_truth_rule`)
 
 ## Lifecycle statuses
 Use only canonical statuses:
@@ -36,3 +37,11 @@ Before demand exists, continuity must be captured in `exchange/chatgpt/sessions/
 - `execution_gate: now` -> active execution package
 - `execution_gate: quick_win` -> may be attached by Codex only when safe/coherent
 - `execution_gate: backlog` -> preserved and visible; not silently executed
+
+## Execution-gate label mapping
+- `execution_gate: now` -> `gate:now`
+- `execution_gate: quick_win` -> `gate:quick-win`
+- `execution_gate: backlog` -> `gate:backlog`
+
+Labels are indexing/routing helpers only.
+Detailed truth remains in demand artifact sections.

--- a/exchange/chatgpt/demands/TEMPLATE__intake_v1.md
+++ b/exchange/chatgpt/demands/TEMPLATE__intake_v1.md
@@ -35,12 +35,21 @@ actor: chatgpt
 
 ## execution gate
 - execution_gate: now
+- execution_gate_label: gate:now
 - why_now:
 - why_not_now:
 - promotion_trigger:
 - safe_to_attach_to_current_package: yes
 - related_files_outputs:
 - impacted_portfolio_component:
+
+## label index (query/routing)
+- expected_labels:
+  - gate:now
+  - state:ready-for-agent
+  - component:<component>
+  - agent:<agent-lane>
+- label_truth_rule: labels route/query only; repo sections in this file remain canonical detailed truth
 
 ## lifecycle tracking
 - source_pr_url:

--- a/exchange/chatgpt/ideas/README.md
+++ b/exchange/chatgpt/ideas/README.md
@@ -12,3 +12,12 @@ Execution gate rule:
 - every idea seed must include `execution_gate: now|quick_win|backlog` and companion rationale fields
 - quick wins may be attached by Codex only when safe/coherent
 - backlog ideas must preserve summary, impacted portfolio/component, related outputs, why_not_now, and promotion_trigger
+
+Execution-gate label mapping:
+- `execution_gate: now` -> `gate:now`
+- `execution_gate: quick_win` -> `gate:quick-win`
+- `execution_gate: backlog` -> `gate:backlog`
+
+Owner-query indexing:
+- labels are the index for routing/query
+- idea artifact fields remain canonical detailed truth

--- a/exchange/chatgpt/ideas/TEMPLATE__idea_seed_v1.md
+++ b/exchange/chatgpt/ideas/TEMPLATE__idea_seed_v1.md
@@ -22,12 +22,20 @@ actor: chatgpt
 
 ## execution gate
 - execution_gate: backlog
+- execution_gate_label: gate:backlog
 - why_now:
 - why_not_now:
 - promotion_trigger:
 - safe_to_attach_to_current_package: no
 - related_files_outputs:
 - impacted_portfolio_component:
+
+## label index (query/routing)
+- expected_labels:
+  - type:idea
+  - gate:backlog
+  - component:<component>
+- label_truth_rule: labels route/query only; idea details in this file remain canonical truth
 
 ## handover
 - set `status: ready-for-codex` when complete

--- a/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
+++ b/journals/system-integration-normalization/DECISIONS_system_integration_normalization_v9.md
@@ -270,3 +270,12 @@ Status note: this v9 file remains the current SI/N decision addendum and is upda
 - What it affects: demand/idea templates, exchange governance wording, owner board generation, and owner status/dashboard guidance.
 - What it explicitly does NOT affect: manual owner routing/decomposition work or unrelated governance/runtime packages.
 - Follow-up needed: ensure each active demand/idea artifact maintains gate fields and portfolio metadata so quick-win pull-in and backlog preservation remain auditable.
+
+### DEC-system_integration_normalization-42
+- Status: locked
+- Decision: owner repo-truth query surface is label-indexed and artifact-truth-backed; execution gates are standardized as labels `gate:now`, `gate:quick-win`, and `gate:backlog`, while demand/idea/journal/decision artifacts remain canonical detail.
+- Date context: label-only owner query surface hardening phase
+- Why this was chosen: owner needs stable, low-overhead queries (backlog/ideas/blockers/decisions/quick wins/component filters) that do not depend on fragile dashboards or project custom fields.
+- What it affects: issue routing labels, exchange templates/protocol, owner operational query guidance, and ChatGPT answer contract (structured summary + direct Git links + optional label-filter URL + explicit owner todo).
+- What it explicitly does NOT affect: creation of new dashboard/board/html surfaces or replacement of repo-truth artifact content with labels.
+- Follow-up needed: keep label index and artifact truth synchronized and treat any mismatch as a repo-truth defect.

--- a/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
+++ b/journals/system-integration-normalization/STATUS_system_integration_normalization_v8.md
@@ -29,6 +29,7 @@ Status note: this v8 file remains the current SI/N status addendum and is update
   - bridge and tuner are both enabled in the autonomous delivery support matrix
 - what partially works:
   - execution-gate model (`now|quick_win|backlog`) is now standardized for demand/idea items with promotion rationale and related outputs fields
+  - owner repo-truth query model is now explicitly label-indexed (`gate:now|gate:quick-win|gate:backlog`, `state:blocked`, `state:needs-decision|state:awaiting-owner`, `component:<x>`) while canonical detail remains in demand/idea/journal/decision artifacts
   - owner-minimal chat handoff now uses only `governed mode on` and `ship to codex` before merge-after-pre-ok; internal `chatok` and demand closure are automation-owned
   - governed chat mode can now persist live session continuity artifacts under `exchange/chatgpt/sessions/` and promote `chatok` sessions into `ready-for-codex` demand artifacts
   - chat-to-demand exchange lane remains active under `exchange/chatgpt/` with watcher support for `ready-for-codex` artifacts
@@ -152,3 +153,4 @@ Status note: this v8 file remains the current SI/N status addendum and is update
 6. keep owner command surface constrained to `governed mode on | ship to codex | merge after pre-ok` for governed chat lanes
 7. keep owner-facing boards/index synchronized with demand `pre-ok` and `ready-for-owner` visibility
 8. keep owner-facing portfolio visibility synchronized for `now|quick_win|backlog` rows in existing owner boards
+9. keep owner query answers link-first (direct Git object links + optional label-filter URLs) and avoid introducing new dashboard/HTML surfaces for queryability

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -4,6 +4,12 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 
 ## Entries
 
+### 2026-04-17 / si/label-only-owner-query-surface-v1 / label-indexed owner repo-truth query surface
+- standardized execution-gate labels for owner query/indexing (`gate:now`, `gate:quick-win`, `gate:backlog`) and aligned issue-routing governance wording
+- updated exchange demand/idea templates + protocol so labels are index/routing metadata while repo artifacts remain canonical detail truth
+- added canonical owner query guidance for repo-truth prompts (backlog, ideas, blockers, decisions awaiting owner, quick wins, component-filtered variants) with required ChatGPT response shape (structured summary, direct Git links, optional label URL, explicit owner todo/no-action)
+- purpose: make owner queries reliably answerable from labels + repo truth without adding new dashboards/boards/html surfaces or custom-field dependency
+
 ### 2026-04-17 / si/execution-gate-and-backlog-portfolio-v1 / execution-gate + backlog portfolio visibility
 - standardized execution gate model (`now|quick_win|backlog`) with mandatory rationale/promotion fields for demand and idea artifacts
 - codified quick-win attachment rule for Codex and explicit downgrade-to-backlog behavior when safety/coherence checks fail


### PR DESCRIPTION
Package: label-only owner query surface v1.

This PR standardizes execution-gate labels (`gate:now`, `gate:quick-win`, `gate:backlog`) as query index labels while keeping repo artifacts as canonical truth; updates demand/idea templates and owner query contract for link-first repo-truth answers.