### PR TITLE
docs(owner): add one-line owner policy

### DIFF
--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -3,6 +3,9 @@
 ## Purpose
 This is the single owner-facing page for decisions, onboarding links, governance operations, and review workflow.
 
+## Owner policy (one-line)
+Discuss in chat, ship to Codex, review only repo-ready output, merge only after ChatGPT `pre-ok`; all routing, decomposition, documentation, closeout, and truth maintenance are execution-lane responsibilities, not owner work.
+
 ## Owner role boundary (non-negotiable)
 - Owner is expected to decide, not to execute PR mechanics.
 - Agents/chats/Codex lanes must create/update branches and PRs and deliver decision-ready packets.


### PR DESCRIPTION
## Summary
- add one concise owner policy line to the canonical owner operational reference
- anchor the minimal owner role directly in the owner-facing page
- keep the change narrow and documentation-only

## Why
The owner wanted the minimal operating principle written into Git in the place where it belongs, without adding more governance surface area.

## Validation
- updated canonical owner-facing document only
- no new dashboard, board, or extra process layer added
