### PR TITLE
Formalize full agent registry roles and deterministic startup alignment

### DIFF
--- a/docs/agents/agent_git_bootstrap_v1.md
+++ b/docs/agents/agent_git_bootstrap_v1.md
@@ -32,7 +32,7 @@ Behavior:
 - if missing, it is created from `git/main`
 - invalid branch names (not `si/*`, `dev/*`, `integration/*`) are rejected
 - if `GH_TOKEN`/`GITHUB_TOKEN` exists and plain push auth fails, bootstrap configures a local repo credential helper for `https://github.com` and re-probes push auth
-- role hint output provides branch hint + startup packet lines for faster onboarding (`--role tuner|bridge|hardware|si|governance|generic`)
+- role hint output provides branch hint + startup packet lines for faster onboarding (`--role tuner|bridge|hardware|fun-line|autoswitch|ux|si|governance|generic`)
 - mode-B output keeps startup to need-to-know lines and emits one deferred packet pointer map (`docs/agents/role_bootstrap_reference_map_v1.md`) plus role profile source (`docs/agents/role_bootstrap_profiles_v1.md`) to avoid information loss while reducing initial read time
 
 Optional environment overrides:
@@ -41,7 +41,7 @@ Optional environment overrides:
 - `CANONICAL_BASE_BRANCH` (default: `main`)
 - `AUTO_SYNC_MAIN` (default: `true`) to auto-fetch/rebase `si/*`, `dev/*`, and `integration/*` branches onto latest `git/main`
 - `ROLE_HINT` (default: `generic`) role profile hint used for startup/deferred packet output
-  - supported role hints: `tuner | bridge | hardware | si | governance | generic`
+  - supported role hints: `tuner | bridge | hardware | fun-line | autoswitch | ux | si | governance | generic`
 - `BOOTSTRAP_CONTEXT_MODE` (default: `classic`) one of `classic` or `mode-b`
 
 ## Required first reply contract (agent -> owner)

--- a/docs/agents/agent_registry_v1.md
+++ b/docs/agents/agent_registry_v1.md
@@ -29,10 +29,10 @@ Each agent entry must provide:
 | dev-bridge | available | component-developer | dev/bridge | bridge | docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role | bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b | yes |
 | dev-generic | available | generic-developer | dev/<component> or si/<topic> | - | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | yes |
 | dev-hardware | available | hardware-developer | dev/hardware | hardware | docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role | bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b | yes |
-| dev-fun-line | planned | component-developer | dev/fun-line | fun-line | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
+| dev-fun-line | planned | component-developer | dev/fun-line | fun-line | docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role | bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b | no |
 | dev-starter | planned | component-developer | dev/starter | starter | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
-| dev-autoswitch | planned | component-developer | dev/autoswitch | autoswitch | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
-| dev-ux | planned | ux-developer | si/<topic> or dev/<component> | ui | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
+| dev-autoswitch | planned | component-developer | dev/autoswitch | autoswitch | docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role | bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b | no |
+| dev-ux | planned | ux-developer | si/<topic> or dev/<component> | ui | docs/agents/agent_role_start_prompts_v1.md#dev-ux-role | bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b | no |
 
 ## SI delegation rule
 SI must consult this registry before delegation and only delegate direct work to agents with:
@@ -43,3 +43,8 @@ If required role is unavailable/planned:
 - suggest `startup_prompt_path`
 - suggest `bootstrap_command`
 - keep ownership with SI until role becomes available.
+
+## Registry helper commands
+- list: `python3 tools/governance/agent_registry_helper_v1.py --list`
+- one start command: `python3 tools/governance/agent_registry_helper_v1.py --start-command <agent_id>`
+- validation: `python3 tools/governance/agent_registry_helper_v1.py --validate`

--- a/docs/agents/agent_role_start_prompts_v1.md
+++ b/docs/agents/agent_role_start_prompts_v1.md
@@ -51,3 +51,33 @@ Bootstrap in mode-b hardware profile, inspect hardware constraints/current-state
 3) next branch-safe implementation step.
 Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b
 ```
+
+## Dev Fun Line role
+```text
+You are now the dev-fun-line developer agent for SH99999/mediastreamer.
+Bootstrap in mode-b fun-line profile, inspect fun-line current-state/deploy constraints, and return:
+1) safe fun-line change scope
+2) blockers
+3) next branch-safe implementation step.
+Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b
+```
+
+## Dev AutoSwitch role
+```text
+You are now the dev-autoswitch developer agent for SH99999/mediastreamer.
+Bootstrap in mode-b autoswitch profile, inspect autoswitch current-state constraints, and return:
+1) safe autoswitch change scope
+2) blockers
+3) next branch-safe implementation step.
+Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b
+```
+
+## Dev UX role
+```text
+You are now the dev-ux developer agent for SH99999/mediastreamer.
+Bootstrap in mode-b ux profile, inspect UI/UX governance constraints, and return:
+1) safe UX change scope
+2) blockers
+3) next branch-safe implementation step.
+Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b
+```

--- a/docs/agents/agent_start_index_v1.md
+++ b/docs/agents/agent_start_index_v1.md
@@ -9,11 +9,16 @@ Quick owner-facing index for agent availability and startup instructions.
 | Dev Bridge (`dev-bridge`) | yes | bridge component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b` |
 | Dev Generic (`dev-generic`) | yes | governed implementation where role specialization is not required | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
 | Dev Hardware (`dev-hardware`) | yes | hardware component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b` |
-| Dev Fun Line (`dev-fun-line`) | no (planned) | fun-line specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
+| Dev Fun Line (`dev-fun-line`) | no (planned) | fun-line specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b` |
 | Dev Starter (`dev-starter`) | no (planned) | starter specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
-| Dev AutoSwitch (`dev-autoswitch`) | no (planned) | autoswitch specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
-| Dev UX (`dev-ux`) | no (planned) | UI/UX implementation lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
+| Dev AutoSwitch (`dev-autoswitch`) | no (planned) | autoswitch specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b` |
+| Dev UX (`dev-ux`) | no (planned) | UI/UX implementation lane | `docs/agents/agent_role_start_prompts_v1.md#dev-ux-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b` |
 
 Canonical registry source:
 - `docs/agents/agent_registry_v1.md`
 - `tools/governance/agent_registry_v1.json`
+
+Codex startup helpers:
+- list agents: `python3 tools/governance/agent_registry_helper_v1.py --list`
+- print one start command: `python3 tools/governance/agent_registry_helper_v1.py --start-command <agent_id>`
+- validate registry/startup alignment: `python3 tools/governance/agent_registry_helper_v1.py --validate`

--- a/docs/agents/role_bootstrap_profiles_v1.md
+++ b/docs/agents/role_bootstrap_profiles_v1.md
@@ -41,6 +41,30 @@ Mode-B is optimization only. It does not relax branch doctrine, protected-`main`
   - `journals/scale-radio-hardware/stream_v1.md`
   - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
 
+### fun-line
+- branch hint: `dev/fun-line`
+- startup add-on:
+  - `journals/scale-radio-fun-line/current_state_v1.md`
+- deferred packet:
+  - `journals/scale-radio-fun-line/stream_v1.md`
+  - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
+
+### autoswitch
+- branch hint: `dev/autoswitch`
+- startup add-on:
+  - `journals/scale-radio-autoswitch/current_state_v1.md`
+- deferred packet:
+  - `journals/scale-radio-autoswitch/stream_v1.md`
+  - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
+
+### ux
+- branch hint: `si/<topic>` or `dev/<component>`
+- startup add-on:
+  - `contracts/repo/ui_gui_governance_standard_v1.md`
+- deferred packet:
+  - `journals/system-integration-normalization/ui_gui_stream_v1.md`
+  - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
+
 ### system-integration / governance
 - branch hint: `si/<topic>`
 - startup add-on:

--- a/docs/agents/role_bootstrap_reference_map_v1.md
+++ b/docs/agents/role_bootstrap_reference_map_v1.md
@@ -21,6 +21,22 @@ Reduce cross-reference maintenance by providing one canonical pointer map for mo
 - startup state source: `journals/scale-radio-bridge/current_state_v1.md`
 - stream source: `journals/scale-radio-bridge/stream_v1.md`
 
+### hardware
+- startup state source: `journals/scale-radio-hardware/current_state_v1.md`
+- stream source: `journals/scale-radio-hardware/stream_v1.md`
+
+### fun-line
+- startup state source: `journals/scale-radio-fun-line/current_state_v1.md`
+- stream source: `journals/scale-radio-fun-line/stream_v1.md`
+
+### autoswitch
+- startup state source: `journals/scale-radio-autoswitch/current_state_v1.md`
+- stream source: `journals/scale-radio-autoswitch/stream_v1.md`
+
+### ux
+- startup governance source: `contracts/repo/ui_gui_governance_standard_v1.md`
+- stream source: `journals/system-integration-normalization/ui_gui_stream_v1.md`
+
 ### system-integration / governance
 - startup governance source: `contracts/repo/system_integration_governance_index_v7.md`
 - onboarding source: `docs/agents/system_integration_recovery_onboarding_v7.md`

--- a/docs/agents/system_integration_recovery_onboarding_v7.md
+++ b/docs/agents/system_integration_recovery_onboarding_v7.md
@@ -34,6 +34,9 @@ Read only these files after Tier 0:
 - `contracts/repo/issue_governance_routing_standard_v1.md`
 - `contracts/repo/system_integration_escalation_contract_v1.md`
 - `docs/agents/si_merge_request_executive_summary_v1.md`
+- `docs/agents/agent_registry_v1.md`
+- `docs/agents/agent_start_index_v1.md`
+- `tools/governance/agent_registry_helper_v1.py` (`--list|--start-command|--validate`)
 
 ### Tier 2 — deep history (read-only)
 Use only for forensic context:

--- a/tools/governance/agent_git_bootstrap_v1.sh
+++ b/tools/governance/agent_git_bootstrap_v1.sh
@@ -18,7 +18,7 @@ Usage:
 
 Options:
   --branch <name>   Explicit branch prep target.
-  --role <name>     Role profile hint (tuner | bridge | hardware | si | governance | generic).
+  --role <name>     Role profile hint (tuner | bridge | hardware | fun-line | autoswitch | ux | si | governance | generic).
   --mode <name>     Context mode:
                     - classic (existing behavior)
                     - mode-b  (need-to-know startup + deferred references)
@@ -85,6 +85,21 @@ role_bootstrap_lines() {
       echo "- role profile: hardware"
       echo "- branch hint: dev/hardware"
       echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; journals/scale-radio-hardware/current_state_v1.md"
+      ;;
+    fun-line|fun_line|funline)
+      echo "- role profile: fun-line"
+      echo "- branch hint: dev/fun-line"
+      echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; journals/scale-radio-fun-line/current_state_v1.md"
+      ;;
+    autoswitch|auto-switch|auto_switch)
+      echo "- role profile: autoswitch"
+      echo "- branch hint: dev/autoswitch"
+      echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; journals/scale-radio-autoswitch/current_state_v1.md"
+      ;;
+    ux|ui-ux|uiux)
+      echo "- role profile: ux"
+      echo "- branch hint: si/<topic> or dev/<component>"
+      echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; contracts/repo/ui_gui_governance_standard_v1.md"
       ;;
     si|system-integration|governance)
       echo "- role profile: system-integration"

--- a/tools/governance/agent_registry_helper_v1.py
+++ b/tools/governance/agent_registry_helper_v1.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+
+REQUIRED_FIELDS = [
+    "agent_id",
+    "display_name",
+    "status",
+    "role",
+    "branch_hint",
+    "scope",
+    "owned_components",
+    "startup_prompt_path",
+    "bootstrap_command",
+    "escalates_to",
+    "can_receive_work_from_si",
+]
+ALLOWED_STATUS = {"available", "unavailable", "planned"}
+ALLOWED_DELEGATION = {"yes", "no"}
+ROLE_MARKERS = {
+    "si": "### system-integration / governance",
+    "dev-tuner": "### tuner",
+    "dev-bridge": "### bridge",
+    "dev-hardware": "### hardware",
+    "dev-fun-line": "### fun-line",
+    "dev-autoswitch": "### autoswitch",
+    "dev-ux": "### ux",
+}
+
+
+def slugify_anchor(text: str) -> str:
+    text = text.strip().lower()
+    text = re.sub(r"[`]+", "", text)
+    text = re.sub(r"[^a-z0-9\s-]", "", text)
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-{2,}", "-", text)
+    return text.strip("-")
+
+
+def load_registry(repo_root: Path) -> dict:
+    path = repo_root / "tools" / "governance" / "agent_registry_v1.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def resolve_prompt_anchor(repo_root: Path, startup_prompt_path: str) -> tuple[Path, str]:
+    if "#" in startup_prompt_path:
+        file_path, anchor = startup_prompt_path.split("#", 1)
+    else:
+        file_path, anchor = startup_prompt_path, ""
+    return (repo_root / file_path, anchor)
+
+
+def normalize_anchor(anchor: str) -> str:
+    return anchor.lstrip("#").strip().lower()
+
+
+def validate(repo_root: Path) -> int:
+    registry = load_registry(repo_root)
+    agents = registry.get("agents", [])
+    prompt_doc = (repo_root / "docs" / "agents" / "agent_role_start_prompts_v1.md").read_text(encoding="utf-8")
+    profile_doc = (repo_root / "docs" / "agents" / "role_bootstrap_profiles_v1.md").read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    prompt_anchors = {f"#{slugify_anchor(h[3:].strip())}" for h in prompt_doc.splitlines() if h.startswith("## ")}
+
+    for agent in agents:
+        missing = [field for field in REQUIRED_FIELDS if field not in agent]
+        if missing:
+            errors.append(f"{agent.get('agent_id', '<unknown>')}:missing_fields={','.join(missing)}")
+            continue
+
+        if agent["status"] not in ALLOWED_STATUS:
+            errors.append(f"{agent['agent_id']}:invalid_status={agent['status']}")
+        if agent["can_receive_work_from_si"] not in ALLOWED_DELEGATION:
+            errors.append(f"{agent['agent_id']}:invalid_delegation_value={agent['can_receive_work_from_si']}")
+        if not str(agent["bootstrap_command"]).startswith("bash tools/governance/agent_git_bootstrap_v1.sh"):
+            errors.append(f"{agent['agent_id']}:invalid_bootstrap_command")
+
+        prompt_path, anchor = resolve_prompt_anchor(repo_root, str(agent["startup_prompt_path"]))
+        if not prompt_path.exists():
+            errors.append(f"{agent['agent_id']}:missing_start_prompt_file={prompt_path.relative_to(repo_root)}")
+        elif anchor and f"#{slugify_anchor(normalize_anchor(anchor))}" not in prompt_anchors:
+            errors.append(f"{agent['agent_id']}:missing_start_prompt_anchor=#{anchor}")
+
+        if agent["status"] == "available":
+            marker = ROLE_MARKERS.get(agent["agent_id"])
+            if marker and marker not in profile_doc:
+                errors.append(f"{agent['agent_id']}:missing_role_profile_marker={marker}")
+
+    if errors:
+        print("agent_registry_alignment=fail")
+        for err in errors:
+            print(f"error:{err}")
+        return 1
+
+    print("agent_registry_alignment=ok")
+    print(f"agents_total={len(agents)}")
+    print(f"agents_available={sum(1 for a in agents if a.get('status') == 'available')}")
+    return 0
+
+
+def list_agents(repo_root: Path) -> int:
+    agents = load_registry(repo_root).get("agents", [])
+    for agent in agents:
+        print(f"{agent['agent_id']}\t{agent['status']}\t{agent['role']}\t{agent['bootstrap_command']}")
+    return 0
+
+
+def start_command(repo_root: Path, agent_id: str) -> int:
+    agents = load_registry(repo_root).get("agents", [])
+    for agent in agents:
+        if agent.get("agent_id") == agent_id:
+            print(agent["bootstrap_command"])
+            return 0
+    print(f"unknown_agent_id={agent_id}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Agent registry helper (list/start-command/validate).")
+    parser.add_argument("--repo-root", default=".", help="Repository root path.")
+    parser.add_argument("--list", action="store_true", help="List agent registry entries.")
+    parser.add_argument("--validate", action="store_true", help="Validate registry alignment.")
+    parser.add_argument("--start-command", metavar="AGENT_ID", help="Print bootstrap command for AGENT_ID.")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+
+    if args.list:
+        return list_agents(repo_root)
+    if args.validate:
+        return validate(repo_root)
+    if args.start_command:
+        return start_command(repo_root, args.start_command)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/governance/agent_registry_v1.json
+++ b/tools/governance/agent_registry_v1.json
@@ -9,7 +9,9 @@
       "role": "system-integration",
       "branch_hint": "si/<topic>",
       "scope": "governance control-plane, cross-component normalization, repo-truth integration",
-      "owned_components": ["system-integration"],
+      "owned_components": [
+        "system-integration"
+      ],
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#si-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b",
       "escalates_to": "owner",
@@ -22,7 +24,9 @@
       "role": "component-developer",
       "branch_hint": "dev/tuner",
       "scope": "tuner component implementation and deploy-lane maintenance",
-      "owned_components": ["tuner"],
+      "owned_components": [
+        "tuner"
+      ],
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b",
       "escalates_to": "si",
@@ -35,7 +39,9 @@
       "role": "component-developer",
       "branch_hint": "dev/bridge",
       "scope": "bridge overlay/runtime and rollback-safe changes",
-      "owned_components": ["bridge"],
+      "owned_components": [
+        "bridge"
+      ],
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b",
       "escalates_to": "si",
@@ -61,7 +67,9 @@
       "role": "hardware-developer",
       "branch_hint": "dev/hardware",
       "scope": "hardware component behavior, constraints, and integration-ready docs",
-      "owned_components": ["hardware"],
+      "owned_components": [
+        "hardware"
+      ],
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b",
       "escalates_to": "si",
@@ -74,9 +82,11 @@
       "role": "component-developer",
       "branch_hint": "dev/fun-line",
       "scope": "fun-line component delivery lane",
-      "owned_components": ["fun-line"],
-      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
-      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
+      "owned_components": [
+        "fun-line"
+      ],
+      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role",
+      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b",
       "escalates_to": "si",
       "can_receive_work_from_si": "no"
     },
@@ -87,7 +97,9 @@
       "role": "component-developer",
       "branch_hint": "dev/starter",
       "scope": "starter component delivery lane",
-      "owned_components": ["starter"],
+      "owned_components": [
+        "starter"
+      ],
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
       "escalates_to": "si",
@@ -100,9 +112,11 @@
       "role": "component-developer",
       "branch_hint": "dev/autoswitch",
       "scope": "autoswitch component delivery lane",
-      "owned_components": ["autoswitch"],
-      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
-      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
+      "owned_components": [
+        "autoswitch"
+      ],
+      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role",
+      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b",
       "escalates_to": "si",
       "can_receive_work_from_si": "no"
     },
@@ -113,9 +127,11 @@
       "role": "ux-developer",
       "branch_hint": "si/<topic> or dev/<component>",
       "scope": "ui/ux governance-aligned design implementation",
-      "owned_components": ["ui"],
-      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
-      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
+      "owned_components": [
+        "ui"
+      ],
+      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-ux-role",
+      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b",
       "escalates_to": "si",
       "can_receive_work_from_si": "no"
     }

--- a/tools/governance/run_integration_check_one_click_v1.py
+++ b/tools/governance/run_integration_check_one_click_v1.py
@@ -102,9 +102,10 @@ def render_report(results: list[CheckResult], out_path: Path) -> None:
         "1. report generation",
         "2. next-owner-click enforcement",
         "3. component claim consistency check",
-        "4. source registry lint",
-        "5. SI branch-scope guard",
-        "6. one-click field presence sweep",
+        "4. agent registry alignment check",
+        "5. source registry lint",
+        "6. SI branch-scope guard",
+        "7. one-click field presence sweep",
     ])
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -118,6 +119,7 @@ def main() -> int:
         run(f"python3 tools/governance/generate_status_reports_v1.py --repo-root . --out-dir reports/status --generated-at {timestamp}", root),
         run("python3 tools/governance/status_next_owner_click_enforcement_v1.py", root),
         run("python3 tools/governance/component_claim_consistency_check_v1.py", root),
+        run("python3 tools/governance/agent_registry_helper_v1.py --validate", root),
         run("python3 tools/governance/governance_source_registry_lint_v1.py", root),
         run("bash -lc \"printf 'contracts/repo/owner_decision_scoring_and_rollback_contract_v1.md\\n' > /tmp/changed_files_guard.txt && python3 tools/governance/si_branch_scope_guard_v1.py --branch si/governance-integration-check-v1 --changed-files /tmp/changed_files_guard.txt --enforce true\"", root),
         one_click_presence(root),


### PR DESCRIPTION
## Summary
- formalizes first-class startup roles for `dev-fun-line`, `dev-autoswitch`, and `dev-ux` across role profiles, start prompts, and bootstrap role hints
- aligns canonical registry/start index entries so these roles point to dedicated prompts and role-specific bootstrap commands
- adds a lightweight helper `tools/governance/agent_registry_helper_v1.py` for listing agents, printing deterministic start commands, and validating registry/startup/profile alignment
- wires the helper validation into the one-click integration check so registry/startup drift is caught automatically
- updates SI onboarding references to include registry/start-index/helper lookup paths

## Validation
- python3 -m py_compile tools/governance/agent_registry_helper_v1.py tools/governance/run_integration_check_one_click_v1.py
- bash -n tools/governance/agent_git_bootstrap_v1.sh
- python3 tools/governance/agent_registry_helper_v1.py --validate
- python3 tools/governance/agent_registry_helper_v1.py --start-command dev-ux
- python3 tools/governance/run_integration_check_one_click_v1.py
- bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b
