### PR TITLE
si: make ChatGPT pre-ok optional in owner merge path

### DIFF
--- a/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
+++ b/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
@@ -39,7 +39,7 @@ After activation:
 - codex execution handoff must route through governed demand artifacts
 
 ## End-to-end governed chain (mandatory)
-`chat -> governed mode on -> live session artifact -> ship to codex -> ready-for-codex demand + protocol-main update + inbox-main pickup snapshot -> codex pickup from main inbox -> in-execution -> ready-for-chatgpt-review -> (pre-ok OR owner-override) -> ready-for-owner -> closed`
+`chat -> governed mode on -> live session artifact -> ship to codex -> ready-for-codex demand + protocol-main update + inbox-main pickup snapshot -> codex pickup from main inbox -> in-execution -> ready-for-chatgpt-review -> (optional pre-ok/changes-requested) -> ready-for-owner -> closed`
 
 Rules:
 - Codex executes from demand artifacts stored in Git.
@@ -162,10 +162,8 @@ Required companion fields:
 4. Demand is moved to `status: ready-for-codex`.
 5. Codex marks `status: in-execution` while implementing governed repo changes.
 6. Codex marks `status: ready-for-chatgpt-review` after implementation artifacts + PR are prepared.
-7. ChatGPT reviews against demand + repo truth and sets `status: pre-ok` or `status: changes-requested`.
-8. Codex updates owner packet and sets `status: ready-for-owner` when either:
-   - ChatGPT path: `chatgpt_review_result: pre-ok`
-   - Owner override path: `chatgpt_review_result: owner-override` and `owner_review_override: yes`
+7. ChatGPT review is optional advisory input; when performed, set `status: pre-ok` or `status: changes-requested`.
+8. Codex updates owner packet and sets `status: ready-for-owner` when PR + rollback + evidence + next_owner_click are ready in repo truth (with or without ChatGPT review).
 9. Owner decides/merges; demand closes automatically after merge + governance closeout completion.
 
 ## Living exchange stream (mandatory)
@@ -204,17 +202,17 @@ Required companion fields:
   - `materialized_protocol: exchange/chatgpt/protocol-main/<topic>__protocol_v1.md`
   - `main_inbox_snapshot: exchange/chatgpt/inbox-main/<timestamp>__<topic>__intake_snapshot_v1.md`
 
-## ChatGPT review/pre-ok gate
+## ChatGPT review/pre-ok (optional advisory)
 - Codex implementation output must include documented branch/PR/rollback path.
 - demand artifacts in `ready-for-chatgpt-review` must include `source_pr_url`, `source_branch`, and `review_target_artifacts`.
 - ChatGPT review compares implementation output against demand + repo truth.
-- Demand lifecycle must not advance to `ready-for-owner` without either `pre-ok` or explicit owner override markers (`chatgpt_review_result: owner-override` + `owner_review_override: yes`).
+- Demand lifecycle may advance to `ready-for-owner` without `pre-ok` if repo-truth owner packet requirements are satisfied.
 - Existing owner-facing surfaces (owner action board / owner decision board / status index / owner dashboard) must expose `pre-ok`, `ready-for-owner`, PR link, and next owner click without requiring owner lifecycle reconstruction.
 
 ## Canonical owner decision markers (label/artifact first)
 - canonical progression uses structured repo-visible markers (demand fields + structured PR decision comment + synchronized labels/state)
 - Project custom fields are optional convenience and must not be required for progression
-- owner override without ChatGPT `pre-ok` is allowed only via explicit marker path and must remain auditable
+- if owner override markers are used, they remain explicit/auditable and must not be represented as `pre-ok`
 
 Structured decision comment fields (canonical):
 - `decision`
@@ -303,7 +301,7 @@ Execution packages must update durable repo truth when impacted:
 - all protected truth still merges via PR to `main`
 - if connector/auth is blocked, produce explicit blocker + one owner action
 - no new dashboards/boards/html surfaces are required by this standard
-- owner command surface should remain minimal: `governed mode on`, `ship to codex`, `review now`, `merge after pre-ok`
+- owner command surface should remain minimal: `governed mode on`, `ship to codex`, `review now`, `merge when repo-ready` (`pre-ok` optional advisory)
 
 ## Governance freeze rule (post-package)
 After this package, governance/process expansion is frozen.

--- a/contracts/repo/system_integration_governance_index_v7.md
+++ b/contracts/repo/system_integration_governance_index_v7.md
@@ -67,7 +67,7 @@ Tier-2 deep-history references are read-only and listed in:
 - Chat-to-demand continuity is mandatory: relevant chat outcomes must be captured to `exchange/chatgpt/sessions/` within 5 minutes, then promoted to `exchange/chatgpt/demands/` at owner command `ship to codex` (internal `chatok`)
 - owner review pickup command is `review now`, resolved from demand artifacts marked `ready-for-chatgpt-review`
 - structured repo-visible decision markers are canonical; Project custom fields are optional convenience only
-- owner override without ChatGPT pre-ok is allowed only via explicit auditable override markers and must not be represented as pre-ok
+- ChatGPT `pre-ok` is optional advisory; owner decision remains repo-truth based, and any override markers used must stay explicit/auditable and must not be represented as pre-ok
 - SI delegation must use canonical agent registry availability (`docs/agents/agent_registry_v1.md` / `tools/governance/agent_registry_v1.json`) before assigning work
 - Chat execution-gate classification is mandatory for demand/idea items: `now | quick_win | backlog` with promotion rationale and related outputs preserved in repo truth
 - execution-gate labels are standardized for owner query/indexing: `gate:now`, `gate:quick-win`, `gate:backlog`

--- a/docs/agents/chatgpt_capture_to_demand_prompt_v1.md
+++ b/docs/agents/chatgpt_capture_to_demand_prompt_v1.md
@@ -46,7 +46,7 @@ in-execution -> ready-for-chatgpt-review -> pre-ok -> ready-for-owner -> closed
 Owner command surface must stay minimal:
 - governed mode on
 - ship to codex
-- merge after pre-ok
+- merge when PR is decision-ready on repo truth (`pre-ok` optional advisory)
 ```
 
 ## Owner handoff rule

--- a/docs/agents/chatgpt_owner_quickstart_v1.md
+++ b/docs/agents/chatgpt_owner_quickstart_v1.md
@@ -8,7 +8,7 @@ Provide the minimum owner command path for governed ChatGPT↔Codex operation.
 2. discussion
 3. `ship to codex`
 4. `review now`
-5. merge to `main` after ChatGPT `pre-ok`
+5. merge to `main` when PR is decision-ready on repo truth (`pre-ok` optional advisory)
 
 ## Review pickup marker (single source)
 Use demand artifacts under `exchange/chatgpt/demands/` and locate:
@@ -22,7 +22,7 @@ Required references in the same demand:
 ## Owner action intent
 - `review now` means ChatGPT should pick up demands marked `ready-for-chatgpt-review` and review against listed source refs.
 - `chatok` and demand closeout remain internal automation/lifecycle mechanics.
-- if owner intentionally proceeds without ChatGPT `pre-ok`, use structured decision block with `review_override: yes` (explicit, auditable, not `pre-ok`).
+- ChatGPT `pre-ok` remains optional advisory; owner can decide directly from repo-truth packet and PR evidence.
 - owner does not need to tell Codex which side branch to inspect; `ship to codex` publishes canonical pickup snapshot under `exchange/chatgpt/inbox-main/` on `main`.
 
 ## Guardrails

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -4,7 +4,7 @@
 This is the single owner-facing page for decisions, onboarding links, governance operations, and review workflow.
 
 ## Owner policy (one-line)
-Discuss in chat, ship to Codex, review only repo-ready output, merge only after ChatGPT `pre-ok`; all routing, decomposition, documentation, closeout, and truth maintenance are execution-lane responsibilities, not owner work.
+Discuss in chat, ship to Codex, review repo-ready output, and decide merge on repo truth; ChatGPT `pre-ok` is optional advisory input, while routing/decomposition/documentation/closeout/truth maintenance remain execution-lane responsibilities.
 
 ## Owner role boundary (non-negotiable)
 - Owner is expected to decide, not to execute PR mechanics.
@@ -45,9 +45,9 @@ Project custom fields may be used as optional convenience only.
 Automation syncs labels/state from the structured PR comment through `owner-decision-click-sync.yml`.
 Rollback switch: set repository variable `OWNER_DECISION_AUTOMATION_ENABLED=false` to disable automation and return to manual labeling/comments.
 
-Owner override path (explicit):
-- set `review_override: yes` only when intentionally proceeding without ChatGPT `pre-ok`
-- this path is auditable and must not be represented as `pre-ok`
+ChatGPT review path (optional):
+- `review_override` remains available for explicit audit signaling but is not required for owner progression.
+- owner merge decision remains repo-truth based even when no ChatGPT `pre-ok` is present.
 
 ## Are we ready to develop? (YES/NO gate)
 Answer **YES** only if all are true:
@@ -88,7 +88,7 @@ Packet contract:
 - `governed mode on`
 - `ship to codex`
 - `review now`
-- merge to `main` after ChatGPT `pre-ok`
+- merge to `main` when PR is decision-ready on repo truth (`pre-ok` optional)
 
 Review-ready pickup marker:
 - demand `status: ready-for-chatgpt-review`

--- a/exchange/chatgpt/PROTOCOL_v1.md
+++ b/exchange/chatgpt/PROTOCOL_v1.md
@@ -26,7 +26,7 @@ Each active exchange artifact must contain one status marker line:
 - `status: <allowed-status>`
 
 ## Handshake order
-`chat -> governed mode on -> live session artifact -> ship to codex -> demand ready-for-codex + protocol-main update + inbox-main snapshot(pickup-ready) -> codex pickup from main inbox -> in-execution -> ready-for-chatgpt-review -> (pre-ok OR owner-override) -> ready-for-owner -> closed`
+`chat -> governed mode on -> live session artifact -> ship to codex -> demand ready-for-codex + protocol-main update + inbox-main snapshot(pickup-ready) -> codex pickup from main inbox -> in-execution -> ready-for-chatgpt-review -> (optional pre-ok/changes-requested) -> ready-for-owner -> closed`
 
 Detailed behavior:
 1. ChatGPT activates the thread using `governed mode on`.
@@ -39,14 +39,12 @@ Detailed behavior:
      - `source_pr_url`
      - `source_branch`
      - `review_target_artifacts`
-7. ChatGPT reviews against demand + repo truth; set `status: pre-ok` or `status: changes-requested`.
-8. Codex prepares owner packet and sets `status: ready-for-owner` when either:
-   - `chatgpt_review_result: pre-ok`
-   - explicit owner override is recorded (`chatgpt_review_result: owner-override` and `owner_review_override: yes`)
+7. ChatGPT review is optional advisory input; if performed, set `status: pre-ok` or `status: changes-requested`.
+8. Codex prepares owner packet and sets `status: ready-for-owner` once PR + rollback + evidence + next_owner_click are ready in repo truth (independent of ChatGPT review presence).
 9. After owner decision/merge and governance closeout completion, demand status is auto-moved to `closed`.
 
 Override constraints:
-- override is explicit and auditable
+- if override markers are used, they remain explicit and auditable
 - override must not be represented as `pre-ok`
 
 ## Continuity rule

--- a/exchange/chatgpt/demands/TEMPLATE__intake_v1.md
+++ b/exchange/chatgpt/demands/TEMPLATE__intake_v1.md
@@ -62,4 +62,4 @@ actor: chatgpt
 - owner_review_override: no
 - owner_override_note:
 - governance_closeout_status: pending
-- next_owner_click: merge after pre-ok
+- next_owner_click: review decision-ready PR packet and merge if accepted (`pre-ok` optional advisory)

--- a/exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+++ b/exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
@@ -1,0 +1,79 @@
+# chatgpt-preok-optional-owner-repo-truth intake v1
+
+status: ready-for-codex
+actor: chatgpt
+
+## source/context
+- source chat/session: current governed ChatGPT session with owner
+- source timestamp (UTC): 2026-04-17T00:00:00Z
+- participants: owner, chatgpt
+
+## objective
+- make ChatGPT `pre-ok` optional advisory instead of required merge gate
+- keep owner merge decision repo-truth first while preserving auditability
+- align canonical owner/exchange docs and demand lifecycle wording
+
+## locked decisions
+1. owner merge decision should not depend on ChatGPT pre-authorization
+2. ChatGPT review remains optional advisory input
+3. project custom fields remain optional convenience and must not become critical-path
+
+## open decisions
+1. none
+
+## required implementation
+1. update canonical governance/exchange docs to reflect optional advisory pre-ok
+2. publish canonical main inbox snapshot and linked demand/protocol artifacts for pickup
+
+## required governance updates
+1. 
+
+## risks
+1. wording drift across owner/exchange docs if lifecycle language is not synchronized
+
+## non-loss requirements
+1. preserve continuity from this chat in repo artifacts
+2. keep explicit auditability when override markers are used
+
+## execution request for Codex
+- execution branch: si/chatgpt-preok-optional-owner-repo-truth
+- required output: PR to `main` + decision-ready packet + rollback command + next owner click
+
+## execution gate
+- execution_gate: now
+- execution_gate_label: gate:now
+- why_now:
+- why_not_now:
+- promotion_trigger:
+- safe_to_attach_to_current_package: yes
+- related_files_outputs:
+- impacted_portfolio_component:
+
+## label index (query/routing)
+- expected_labels:
+  - gate:now
+  - state:ready-for-agent
+  - component:<component>
+  - agent:<agent-lane>
+- label_truth_rule: labels route/query only; repo sections in this file remain canonical detailed truth
+
+## lifecycle tracking
+- codex_trigger: ship-to-codex
+- materialized_protocol: exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
+- main_inbox_snapshot: exchange/chatgpt/inbox-main/<timestamp>__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+- source_pr_url:
+- source_branch:
+- review_target_artifacts:
+- chatgpt_review_result: pending
+- owner_review_override: no
+- owner_override_note:
+- governance_closeout_status: pending
+- next_owner_click: review decision-ready PR packet and merge if accepted (`pre-ok` optional advisory)
+
+## promotion metadata
+- promoted_from_live: `exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md`
+- promoted_at_utc: `2026-04-17T11:31:12.552251+00:00`
+- codex_trigger: `ship-to-codex`
+- promotion_trigger: `chatok`
+- materialized_protocol: `exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md`
+- main_inbox_snapshot: ``

--- a/exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+++ b/exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
@@ -1,0 +1,47 @@
+# chatgpt-preok-optional-owner-repo-truth intake snapshot v1
+
+status: pickup-ready
+pickup_rule: main-inbox-v1
+snapshot_immutable: true
+snapshot_id: 20260417T113113Z
+created_at_utc: 2026-04-17T11:31:13Z
+trigger_command: ship to codex
+
+## codex pickup contract
+- execution_branch: si/chatgpt-preok-optional-owner-repo-truth-v1
+- pickup_ready_marker: status: pickup-ready
+- pickup_source: exchange/chatgpt/inbox-main/
+
+## source artifacts
+- demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+- materialized_protocol: exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
+
+## objective
+- make ChatGPT `pre-ok` optional advisory instead of required merge gate
+- keep owner merge decision repo-truth first while preserving auditability
+- align canonical owner/exchange docs and demand lifecycle wording
+
+
+## locked decisions
+1. owner merge decision should not depend on ChatGPT pre-authorization
+2. ChatGPT review remains optional advisory input
+3. project custom fields remain optional convenience and must not become critical-path
+
+
+## open decisions
+1. none
+
+
+## risks
+1. wording drift across owner/exchange docs if lifecycle language is not synchronized
+
+
+## execution requests
+1. update canonical governance/exchange docs to reflect optional advisory pre-ok
+2. publish canonical main inbox snapshot and linked demand/protocol artifacts for pickup
+
+
+## related git objects
+- demand_path: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+- protocol_path: exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
+- snapshot_path: exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md

--- a/exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
+++ b/exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
@@ -1,0 +1,71 @@
+# chatgpt-preok-optional-owner-repo-truth protocol snapshot v1
+
+status: active
+actor: chatgpt-codex
+source_live_session: exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+source_demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+last_event_utc: 2026-04-17T11:31:12.552251+00:00
+
+## current objective
+- 
+
+## material events
+### event 001
+- event_utc:
+- event_type: governed-mode-activated | ship-to-codex-promotion | codex-execution-started | review-ready | pre-ok | changes-requested | owner-override | owner-ready | closed
+- actor: chatgpt | codex | owner
+- summary:
+- locked_decisions:
+  1.
+- open_decisions:
+  1.
+- risks:
+  1.
+- execution_requests:
+  1.
+- related_git_objects:
+  - live_session:
+  - demand_intake:
+  - main_inbox_snapshot:
+  - source_branch:
+  - source_pr_url:
+  - review_target_artifacts:
+
+### event 002
+- event_utc: 2026-04-17T11:31:01.367343+00:00
+- event_type: ship-to-codex-promotion
+- actor: codex
+- summary: promotion from live session to ready-for-codex demand intake completed
+- decisions:
+  1. owner-visible trigger remains `ship to codex`.
+- open_questions:
+  1. none recorded in this event.
+- risks_blockers:
+  1. none recorded in this event.
+- execution_requests:
+  1. execute demand on declared SI branch and prepare PR to main.
+- related_git_objects:
+  - live_session: exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+  - demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+  - source_branch:
+  - source_pr_url:
+  - review_target_artifacts:
+### event 003
+- event_utc: 2026-04-17T11:31:12.552251+00:00
+- event_type: ship-to-codex-promotion
+- actor: codex
+- summary: promotion from live session to ready-for-codex demand intake completed
+- decisions:
+  1. owner-visible trigger remains `ship to codex`.
+- open_questions:
+  1. none recorded in this event.
+- risks_blockers:
+  1. none recorded in this event.
+- execution_requests:
+  1. execute demand on declared SI branch and prepare PR to main.
+- related_git_objects:
+  - live_session: exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+  - demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+  - source_branch:
+  - source_pr_url:
+  - review_target_artifacts:

--- a/exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+++ b/exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
@@ -1,0 +1,37 @@
+# chatgpt-preok-optional-owner-repo-truth live v1
+
+status: chatok
+actor: chatgpt
+last_material_update_utc: 2026-04-17T00:00:00Z
+
+## source/context
+- source chat/session: current governed ChatGPT session with owner
+- source timestamp (UTC): 2026-04-17T00:00:00Z
+- participants: owner, chatgpt
+
+## current objective
+- make ChatGPT `pre-ok` optional advisory instead of required merge gate
+- keep owner merge decision repo-truth first while preserving auditability
+- align canonical owner/exchange docs and demand lifecycle wording
+
+## locked decisions so far
+1. owner merge decision should not depend on ChatGPT pre-authorization
+2. ChatGPT review remains optional advisory input
+3. project custom fields remain optional convenience and must not become critical-path
+
+## open decisions
+1. none
+
+## active implementation asks
+1. update canonical governance/exchange docs to reflect optional advisory pre-ok
+2. publish canonical main inbox snapshot and linked demand/protocol artifacts for pickup
+
+## active risks/blockers
+1. wording drift across owner/exchange docs if lifecycle language is not synchronized
+
+## non-loss requirements
+1. preserve continuity from this chat in repo artifacts
+2. keep explicit auditability when override markers are used
+
+## promotion note
+- promoted to demand intake on `ship to codex`

--- a/journals/system-integration-normalization/stream_v6.md
+++ b/journals/system-integration-normalization/stream_v6.md
@@ -4,6 +4,12 @@ Status note: this v6 file supersedes `stream_v5.md` as the current SI/N stream b
 
 ## Entries
 
+### 2026-04-17 / si/chatgpt-preok-optional-owner-repo-truth-v1 / owner decision path inversion
+- updated canonical exchange/owner docs so ChatGPT `pre-ok` is optional advisory input instead of a required merge gate
+- aligned protocol, exchange operating standard, owner quickstart/reference, SI governance index wording, and demand template next-owner-click guidance with repo-truth-first owner decisioning
+- preserved auditability rule: if override markers are used they must remain explicit and must never be represented as `pre-ok`
+- purpose: keep owner one-click decision flow repo-truth based while retaining optional ChatGPT review signal
+
 ### 2026-04-17 / si/agent-registry-delegation-and-startup-v1 / registry guardrails + SI delegation checklist hardening
 - tightened canonical agent-registry contract by documenting required baseline agent ids (`si`, `dev-tuner`, `dev-bridge`, `dev-generic`, `dev-hardware`, `dev-fun-line`, `dev-autoswitch`, `dev-ux`)
 - extended `tools/governance/agent_registry_helper_v1.py --validate` to enforce required baseline ids and available-agent startup/role-profile alignment checks


### PR DESCRIPTION
## Summary
- make ChatGPT pre-ok optional advisory (not required merge gate) in canonical owner/exchange docs
- align protocol, owner reference/quickstart, exchange standard, SI governance index, and demand template next_owner_click
- preserve explicit/auditable override marker semantics when used

## Validation
- python3 tools/governance/agent_registry_helper_v1.py --validate
- rg consistency scan on updated docs
