### PR TITLE
cleanup(chatgpt): close stale chat status artifacts

### DIFF
--- a/exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+++ b/exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
@@ -1,6 +1,6 @@
 # chatgpt-preok-optional-owner-repo-truth intake v1
 
-status: ready-for-codex
+status: closed
 actor: chatgpt
 
 ## source/context
@@ -60,15 +60,15 @@ actor: chatgpt
 ## lifecycle tracking
 - codex_trigger: ship-to-codex
 - materialized_protocol: exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
-- main_inbox_snapshot: exchange/chatgpt/inbox-main/<timestamp>__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
-- source_pr_url:
-- source_branch:
+- main_inbox_snapshot: exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+- source_pr_url: https://github.com/SH99999/mediastreamer/pull/147
+- source_branch: si/agent-registry-delegation-and-startup-v1
 - review_target_artifacts:
 - chatgpt_review_result: pending
 - owner_review_override: no
 - owner_override_note:
-- governance_closeout_status: pending
-- next_owner_click: review decision-ready PR packet and merge if accepted (`pre-ok` optional advisory)
+- governance_closeout_status: done
+- next_owner_click: none (closed; merged work already present on main)
 
 ## promotion metadata
 - promoted_from_live: `exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md`
@@ -76,4 +76,4 @@ actor: chatgpt
 - codex_trigger: `ship-to-codex`
 - promotion_trigger: `chatok`
 - materialized_protocol: `exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md`
-- main_inbox_snapshot: ``
+- main_inbox_snapshot: `exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md`

--- a/exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+++ b/exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
@@ -1,11 +1,12 @@
 # chatgpt-preok-optional-owner-repo-truth intake snapshot v1
 
-status: pickup-ready
+status: closed
 pickup_rule: main-inbox-v1
 snapshot_immutable: true
 snapshot_id: 20260417T113113Z
 created_at_utc: 2026-04-17T11:31:13Z
 trigger_command: ship to codex
+close_reason: merged-on-main; demand closed
 
 ## codex pickup contract
 - execution_branch: si/chatgpt-preok-optional-owner-repo-truth-v1
@@ -21,27 +22,23 @@ trigger_command: ship to codex
 - keep owner merge decision repo-truth first while preserving auditability
 - align canonical owner/exchange docs and demand lifecycle wording
 
-
 ## locked decisions
 1. owner merge decision should not depend on ChatGPT pre-authorization
 2. ChatGPT review remains optional advisory input
 3. project custom fields remain optional convenience and must not become critical-path
 
-
 ## open decisions
 1. none
 
-
 ## risks
 1. wording drift across owner/exchange docs if lifecycle language is not synchronized
-
 
 ## execution requests
 1. update canonical governance/exchange docs to reflect optional advisory pre-ok
 2. publish canonical main inbox snapshot and linked demand/protocol artifacts for pickup
 
-
 ## related git objects
 - demand_path: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
 - protocol_path: exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
 - snapshot_path: exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+- source_pr_url: https://github.com/SH99999/mediastreamer/pull/147

--- a/exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
+++ b/exchange/chatgpt/protocol-main/chatgpt-preok-optional-owner-repo-truth__protocol_v1.md
@@ -1,13 +1,15 @@
 # chatgpt-preok-optional-owner-repo-truth protocol snapshot v1
 
-status: active
+status: closed
 actor: chatgpt-codex
 source_live_session: exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
 source_demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
-last_event_utc: 2026-04-17T11:31:12.552251+00:00
+last_event_utc: 2026-04-17T11:40:47Z
 
 ## current objective
-- 
+- make ChatGPT `pre-ok` optional advisory instead of required merge gate
+- keep owner merge decision repo-truth first while preserving auditability
+- align canonical owner/exchange docs and demand lifecycle wording
 
 ## material events
 ### event 001
@@ -69,3 +71,24 @@ last_event_utc: 2026-04-17T11:31:12.552251+00:00
   - source_branch:
   - source_pr_url:
   - review_target_artifacts:
+
+### event 004
+- event_utc: 2026-04-17T11:40:47Z
+- event_type: closed
+- actor: codex
+- summary: merged-main delivery present; stale pickup artifacts closed after implementation landed via PR #147
+- locked_decisions:
+  1. owner merge decision is optional-advisory with respect to ChatGPT pre-ok.
+- open_decisions:
+  1. none.
+- risks:
+  1. none requiring further execution.
+- execution_requests:
+  1. none.
+- related_git_objects:
+  - live_session: exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+  - demand_intake: exchange/chatgpt/demands/chatgpt-preok-optional-owner-repo-truth__intake_v1.md
+  - main_inbox_snapshot: exchange/chatgpt/inbox-main/20260417T113113Z__chatgpt-preok-optional-owner-repo-truth__intake_snapshot_v1.md
+  - source_branch: si/agent-registry-delegation-and-startup-v1
+  - source_pr_url: https://github.com/SH99999/mediastreamer/pull/147
+  - review_target_artifacts: docs/agents/owner_operational_reference_v1.md; docs/agents/chatgpt_owner_quickstart_v1.md; exchange/chatgpt/PROTOCOL_v1.md

--- a/exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
+++ b/exchange/chatgpt/sessions/chatgpt-preok-optional-owner-repo-truth__live_v1.md
@@ -1,6 +1,6 @@
 # chatgpt-preok-optional-owner-repo-truth live v1
 
-status: chatok
+status: closed
 actor: chatgpt
 last_material_update_utc: 2026-04-17T00:00:00Z
 
@@ -35,3 +35,9 @@ last_material_update_utc: 2026-04-17T00:00:00Z
 
 ## promotion note
 - promoted to demand intake on `ship to codex`
+
+## close metadata
+- close_reason: merged-on-main
+- closed_by_pr: #147
+- governance_closeout_status: done
+- next_owner_click: none

--- a/exchange/chatgpt/sessions/owner-minimal-chat-handoff__live_v1.md
+++ b/exchange/chatgpt/sessions/owner-minimal-chat-handoff__live_v1.md
@@ -1,6 +1,6 @@
 # owner-minimal-chat-handoff live v1
 
-status: live
+status: closed
 actor: chatgpt
 
 ## source/context
@@ -41,7 +41,13 @@ actor: chatgpt
 3. repo truth should be recoverable by any fresh chat with minimal lag
 
 ## current lifecycle status
-- live
+- closed
+
+## close metadata
+- close_reason: merged-on-main
+- closed_by_prs: #133, #136
+- governance_closeout_status: done
+- next_owner_click: none
 
 ## last material update timestamp
 - 2026-04-17T00:00:00Z


### PR DESCRIPTION
## Summary
- close stale `owner-minimal-chat-handoff` live session after merged main delivery
- close stale `chatgpt-preok-optional-owner-repo-truth` live session, demand, protocol, and inbox-main snapshot after merged main delivery
- keep historical stream entries intact and only correct active artifact statuses

## Why
Some ChatGPT exchange artifacts on `main` were left in active or pickup-ready states even though the corresponding work had already landed on `main`. This cleanup makes the current artifact statuses truthful again and reduces watcher/owner confusion.

## Validation
- reviewed merged PR history for the affected topics
- updated only stale active artifacts; no new process surface added
