### PR TITLE
Governance: clean registry to single active SI agent and archive dev agents

### DIFF
--- a/docs/agents/agent_registry_v1.md
+++ b/docs/agents/agent_registry_v1.md
@@ -23,6 +23,8 @@ Each agent entry must provide:
 
 Required baseline agent ids:
 - `si`
+
+Archived/non-running ids may remain listed for restart traceability:
 - `dev-tuner`
 - `dev-bridge`
 - `dev-generic`
@@ -35,14 +37,14 @@ Required baseline agent ids:
 | agent_id | status | role | branch_hint | owned_components | startup_prompt_path | bootstrap_command | can_receive_work_from_si |
 |---|---|---|---|---|---|---|---|
 | si | available | system-integration | si/<topic> | system-integration | docs/agents/agent_role_start_prompts_v1.md#si-role | bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b | no |
-| dev-tuner | available | component-developer | dev/tuner | tuner | docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role | bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b | yes |
-| dev-bridge | available | component-developer | dev/bridge | bridge | docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role | bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b | yes |
-| dev-generic | available | generic-developer | dev/<component> or si/<topic> | - | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | yes |
-| dev-hardware | available | hardware-developer | dev/hardware | hardware | docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role | bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b | yes |
-| dev-fun-line | planned | component-developer | dev/fun-line | fun-line | docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role | bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b | no |
-| dev-starter | planned | component-developer | dev/starter | starter | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
-| dev-autoswitch | planned | component-developer | dev/autoswitch | autoswitch | docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role | bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b | no |
-| dev-ux | planned | ux-developer | si/<topic> or dev/<component> | ui | docs/agents/agent_role_start_prompts_v1.md#dev-ux-role | bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b | no |
+| dev-tuner | unavailable | component-developer | dev/tuner | tuner | docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role | bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b | no |
+| dev-bridge | unavailable | component-developer | dev/bridge | bridge | docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role | bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b | no |
+| dev-generic | unavailable | generic-developer | dev/<component> or si/<topic> | - | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
+| dev-hardware | unavailable | hardware-developer | dev/hardware | hardware | docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role | bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b | no |
+| dev-fun-line | unavailable | component-developer | dev/fun-line | fun-line | docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role | bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b | no |
+| dev-starter | unavailable | component-developer | dev/starter | starter | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
+| dev-autoswitch | unavailable | component-developer | dev/autoswitch | autoswitch | docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role | bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b | no |
+| dev-ux | unavailable | ux-developer | dev/ux | ui | docs/agents/agent_role_start_prompts_v1.md#dev-ux-role | bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b | no |
 
 ## SI delegation rule
 SI must consult this registry before delegation and only delegate direct work to agents with:

--- a/docs/agents/agent_start_index_v1.md
+++ b/docs/agents/agent_start_index_v1.md
@@ -5,14 +5,14 @@ Quick owner-facing index for agent availability and startup instructions.
 | agent | available | role summary | startup prompt path | bootstrap command |
 |---|---|---|---|---|
 | System Integration (`si`) | yes | governance control-plane + cross-component normalization | `docs/agents/agent_role_start_prompts_v1.md#si-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b` |
-| Dev Tuner (`dev-tuner`) | yes | tuner component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b` |
-| Dev Bridge (`dev-bridge`) | yes | bridge component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b` |
-| Dev Generic (`dev-generic`) | yes | governed implementation where role specialization is not required | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
-| Dev Hardware (`dev-hardware`) | yes | hardware component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b` |
-| Dev Fun Line (`dev-fun-line`) | no (planned) | fun-line specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b` |
-| Dev Starter (`dev-starter`) | no (planned) | starter specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
-| Dev AutoSwitch (`dev-autoswitch`) | no (planned) | autoswitch specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b` |
-| Dev UX (`dev-ux`) | no (planned) | UI/UX implementation lane | `docs/agents/agent_role_start_prompts_v1.md#dev-ux-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b` |
+| Dev Tuner (`dev-tuner`) | no (archived) | tuner component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b` |
+| Dev Bridge (`dev-bridge`) | no (archived) | bridge component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b` |
+| Dev Generic (`dev-generic`) | no (archived) | governed implementation where role specialization is not required | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
+| Dev Hardware (`dev-hardware`) | no (archived) | hardware component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b` |
+| Dev Fun Line (`dev-fun-line`) | no (archived) | fun-line specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b` |
+| Dev Starter (`dev-starter`) | no (archived) | starter specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
+| Dev AutoSwitch (`dev-autoswitch`) | no (archived) | autoswitch specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b` |
+| Dev UX (`dev-ux`) | no (archived) | UI/UX implementation lane (`dev/ux`) | `docs/agents/agent_role_start_prompts_v1.md#dev-ux-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b` |
 
 Canonical registry source:
 - `docs/agents/agent_registry_v1.md`

--- a/tools/governance/agent_registry_helper_v1.py
+++ b/tools/governance/agent_registry_helper_v1.py
@@ -23,13 +23,6 @@ REQUIRED_FIELDS = [
 ]
 REQUIRED_AGENT_IDS = {
     "si",
-    "dev-tuner",
-    "dev-bridge",
-    "dev-generic",
-    "dev-hardware",
-    "dev-fun-line",
-    "dev-autoswitch",
-    "dev-ux",
 }
 ALLOWED_STATUS = {"available", "unavailable", "planned"}
 ALLOWED_DELEGATION = {"yes", "no"}

--- a/tools/governance/agent_registry_v1.json
+++ b/tools/governance/agent_registry_v1.json
@@ -20,7 +20,7 @@
     {
       "agent_id": "dev-tuner",
       "display_name": "Developer Tuner",
-      "status": "available",
+      "status": "unavailable",
       "role": "component-developer",
       "branch_hint": "dev/tuner",
       "scope": "tuner component implementation and deploy-lane maintenance",
@@ -30,12 +30,12 @@
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "yes"
+      "can_receive_work_from_si": "no"
     },
     {
       "agent_id": "dev-bridge",
       "display_name": "Developer Bridge",
-      "status": "available",
+      "status": "unavailable",
       "role": "component-developer",
       "branch_hint": "dev/bridge",
       "scope": "bridge overlay/runtime and rollback-safe changes",
@@ -45,12 +45,12 @@
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "yes"
+      "can_receive_work_from_si": "no"
     },
     {
       "agent_id": "dev-generic",
       "display_name": "Developer Generic",
-      "status": "available",
+      "status": "unavailable",
       "role": "generic-developer",
       "branch_hint": "dev/<component> or si/<topic>",
       "scope": "governed implementation on explicitly assigned scope",
@@ -58,12 +58,12 @@
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "yes"
+      "can_receive_work_from_si": "no"
     },
     {
       "agent_id": "dev-hardware",
       "display_name": "Developer Hardware",
-      "status": "available",
+      "status": "unavailable",
       "role": "hardware-developer",
       "branch_hint": "dev/hardware",
       "scope": "hardware component behavior, constraints, and integration-ready docs",
@@ -73,12 +73,12 @@
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "yes"
+      "can_receive_work_from_si": "no"
     },
     {
       "agent_id": "dev-fun-line",
       "display_name": "Developer Fun Line",
-      "status": "planned",
+      "status": "unavailable",
       "role": "component-developer",
       "branch_hint": "dev/fun-line",
       "scope": "fun-line component delivery lane",
@@ -93,7 +93,7 @@
     {
       "agent_id": "dev-starter",
       "display_name": "Developer Starter",
-      "status": "planned",
+      "status": "unavailable",
       "role": "component-developer",
       "branch_hint": "dev/starter",
       "scope": "starter component delivery lane",
@@ -108,7 +108,7 @@
     {
       "agent_id": "dev-autoswitch",
       "display_name": "Developer AutoSwitch",
-      "status": "planned",
+      "status": "unavailable",
       "role": "component-developer",
       "branch_hint": "dev/autoswitch",
       "scope": "autoswitch component delivery lane",
@@ -123,9 +123,9 @@
     {
       "agent_id": "dev-ux",
       "display_name": "Developer UX",
-      "status": "planned",
+      "status": "unavailable",
       "role": "ux-developer",
-      "branch_hint": "si/<topic> or dev/<component>",
+      "branch_hint": "dev/ux",
       "scope": "ui/ux governance-aligned design implementation",
       "owned_components": [
         "ui"


### PR DESCRIPTION
Implements owner instruction: old agents archived, SI remains the only active agent; creates missing dev/ux branch and aligns UX branch hint in registry/start index.