### PR TITLE
Bootstrap: restore bridge startup and add first-class starter role

### DIFF
--- a/docs/agents/agent_git_bootstrap_v1.md
+++ b/docs/agents/agent_git_bootstrap_v1.md
@@ -32,7 +32,7 @@ Behavior:
 - if missing, it is created from `git/main`
 - invalid branch names (not `si/*`, `dev/*`, `integration/*`) are rejected
 - if `GH_TOKEN`/`GITHUB_TOKEN` exists and plain push auth fails, bootstrap configures a local repo credential helper for `https://github.com` and re-probes push auth
-- role hint output provides branch hint + startup packet lines for faster onboarding (`--role tuner|bridge|hardware|fun-line|autoswitch|ux|si|governance|generic`)
+- role hint output provides branch hint + startup packet lines for faster onboarding (`--role tuner|bridge|starter|hardware|fun-line|autoswitch|ux|si|governance|generic`)
 - mode-B output keeps startup to need-to-know lines and emits one deferred packet pointer map (`docs/agents/role_bootstrap_reference_map_v1.md`) plus role profile source (`docs/agents/role_bootstrap_profiles_v1.md`) to avoid information loss while reducing initial read time
 
 Optional environment overrides:
@@ -41,7 +41,7 @@ Optional environment overrides:
 - `CANONICAL_BASE_BRANCH` (default: `main`)
 - `AUTO_SYNC_MAIN` (default: `true`) to auto-fetch/rebase `si/*`, `dev/*`, and `integration/*` branches onto latest `git/main`
 - `ROLE_HINT` (default: `generic`) role profile hint used for startup/deferred packet output
-  - supported role hints: `tuner | bridge | hardware | fun-line | autoswitch | ux | si | governance | generic`
+  - supported role hints: `tuner | bridge | starter | hardware | fun-line | autoswitch | ux | si | governance | generic`
 - `BOOTSTRAP_CONTEXT_MODE` (default: `classic`) one of `classic` or `mode-b`
 
 ## Required first reply contract (agent -> owner)

--- a/docs/agents/agent_registry_v1.md
+++ b/docs/agents/agent_registry_v1.md
@@ -26,7 +26,6 @@ Required baseline agent ids:
 
 Archived/non-running ids may remain listed for restart traceability:
 - `dev-tuner`
-- `dev-bridge`
 - `dev-generic`
 - `dev-hardware`
 - `dev-fun-line`
@@ -38,11 +37,11 @@ Archived/non-running ids may remain listed for restart traceability:
 |---|---|---|---|---|---|---|---|
 | si | available | system-integration | si/<topic> | system-integration | docs/agents/agent_role_start_prompts_v1.md#si-role | bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b | no |
 | dev-tuner | unavailable | component-developer | dev/tuner | tuner | docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role | bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b | no |
-| dev-bridge | unavailable | component-developer | dev/bridge | bridge | docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role | bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b | no |
+| dev-bridge | available | component-developer | dev/bridge | bridge | docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role | bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b | yes |
 | dev-generic | unavailable | generic-developer | dev/<component> or si/<topic> | - | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
 | dev-hardware | unavailable | hardware-developer | dev/hardware | hardware | docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role | bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b | no |
 | dev-fun-line | unavailable | component-developer | dev/fun-line | fun-line | docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role | bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b | no |
-| dev-starter | unavailable | component-developer | dev/starter | starter | docs/agents/agent_role_start_prompts_v1.md#generic-developer-role | bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b | no |
+| dev-starter | available | component-developer | dev/starter | starter | docs/agents/agent_role_start_prompts_v1.md#dev-starter-role | bash tools/governance/agent_git_bootstrap_v1.sh --role starter --mode mode-b | yes |
 | dev-autoswitch | unavailable | component-developer | dev/autoswitch | autoswitch | docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role | bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b | no |
 | dev-ux | unavailable | ux-developer | dev/ux | ui | docs/agents/agent_role_start_prompts_v1.md#dev-ux-role | bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b | no |
 

--- a/docs/agents/agent_role_start_prompts_v1.md
+++ b/docs/agents/agent_role_start_prompts_v1.md
@@ -32,6 +32,16 @@ Bootstrap in mode-b bridge profile, validate overlay constraints, and return:
 Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b
 ```
 
+## Dev Starter role
+```text
+You are now the dev-starter developer agent for SH99999/mediastreamer.
+Bootstrap in mode-b starter profile, inspect starter constraints/current-state, and return:
+1) safe starter change scope
+2) blockers
+3) next branch-safe implementation step.
+Command baseline: bash tools/governance/agent_git_bootstrap_v1.sh --role starter --mode mode-b
+```
+
 ## Generic developer role
 ```text
 You are now a governed developer agent for SH99999/mediastreamer.

--- a/docs/agents/agent_start_index_v1.md
+++ b/docs/agents/agent_start_index_v1.md
@@ -6,11 +6,11 @@ Quick owner-facing index for agent availability and startup instructions.
 |---|---|---|---|---|
 | System Integration (`si`) | yes | governance control-plane + cross-component normalization | `docs/agents/agent_role_start_prompts_v1.md#si-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b` |
 | Dev Tuner (`dev-tuner`) | no (archived) | tuner component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-tuner-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role tuner --mode mode-b` |
-| Dev Bridge (`dev-bridge`) | no (archived) | bridge component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b` |
+| Dev Bridge (`dev-bridge`) | yes | bridge component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b` |
 | Dev Generic (`dev-generic`) | no (archived) | governed implementation where role specialization is not required | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
 | Dev Hardware (`dev-hardware`) | no (archived) | hardware component developer lane | `docs/agents/agent_role_start_prompts_v1.md#dev-hardware-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role hardware --mode mode-b` |
 | Dev Fun Line (`dev-fun-line`) | no (archived) | fun-line specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-fun-line-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role fun-line --mode mode-b` |
-| Dev Starter (`dev-starter`) | no (archived) | starter specialist lane | `docs/agents/agent_role_start_prompts_v1.md#generic-developer-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b` |
+| Dev Starter (`dev-starter`) | yes | starter specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-starter-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role starter --mode mode-b` |
 | Dev AutoSwitch (`dev-autoswitch`) | no (archived) | autoswitch specialist lane | `docs/agents/agent_role_start_prompts_v1.md#dev-autoswitch-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role autoswitch --mode mode-b` |
 | Dev UX (`dev-ux`) | no (archived) | UI/UX implementation lane (`dev/ux`) | `docs/agents/agent_role_start_prompts_v1.md#dev-ux-role` | `bash tools/governance/agent_git_bootstrap_v1.sh --role ux --mode mode-b` |
 

--- a/docs/agents/role_bootstrap_profiles_v1.md
+++ b/docs/agents/role_bootstrap_profiles_v1.md
@@ -33,6 +33,14 @@ Mode-B is optimization only. It does not relax branch doctrine, protected-`main`
   - `journals/scale-radio-bridge/stream_v1.md`
   - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
 
+### starter
+- branch hint: `dev/starter`
+- startup add-on:
+  - `journals/scale-radio-starter/current_state_v1.md`
+- deferred packet:
+  - `journals/scale-radio-starter/stream_v1.md`
+  - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
+
 ### hardware
 - branch hint: `dev/hardware`
 - startup add-on:
@@ -58,7 +66,7 @@ Mode-B is optimization only. It does not relax branch doctrine, protected-`main`
   - shared deferred refs from `docs/agents/role_bootstrap_reference_map_v1.md`
 
 ### ux
-- branch hint: `si/<topic>` or `dev/<component>`
+- branch hint: `dev/ux`
 - startup add-on:
   - `contracts/repo/ui_gui_governance_standard_v1.md`
 - deferred packet:

--- a/tools/governance/agent_git_bootstrap_v1.sh
+++ b/tools/governance/agent_git_bootstrap_v1.sh
@@ -18,7 +18,7 @@ Usage:
 
 Options:
   --branch <name>   Explicit branch prep target.
-  --role <name>     Role profile hint (tuner | bridge | hardware | fun-line | autoswitch | ux | si | governance | generic).
+  --role <name>     Role profile hint (tuner | bridge | starter | hardware | fun-line | autoswitch | ux | si | governance | generic).
   --mode <name>     Context mode:
                     - classic (existing behavior)
                     - mode-b  (need-to-know startup + deferred references)
@@ -75,6 +75,9 @@ if [[ -z "${REQUESTED_BRANCH}" ]]; then
     bridge)
       REQUESTED_BRANCH="dev/bridge"
       ;;
+    starter)
+      REQUESTED_BRANCH="dev/starter"
+      ;;
     hardware)
       REQUESTED_BRANCH="dev/hardware"
       ;;
@@ -106,6 +109,11 @@ role_bootstrap_lines() {
       echo "- role profile: bridge"
       echo "- branch hint: dev/bridge"
       echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; journals/scale-radio-bridge/current_state_v1.md"
+      ;;
+    starter)
+      echo "- role profile: starter"
+      echo "- branch hint: dev/starter"
+      echo "- startup packet: AGENTS.md; tools/governance/agent_git_bootstrap_v1.sh; docs/agents/agent_git_bootstrap_v1.md; journals/scale-radio-starter/current_state_v1.md"
       ;;
     hardware)
       echo "- role profile: hardware"

--- a/tools/governance/agent_registry_helper_v1.py
+++ b/tools/governance/agent_registry_helper_v1.py
@@ -30,6 +30,7 @@ ROLE_MARKERS = {
     "si": "### system-integration / governance",
     "dev-tuner": "### tuner",
     "dev-bridge": "### bridge",
+    "dev-starter": "### starter",
     "dev-generic": "### generic",
     "dev-hardware": "### hardware",
     "dev-fun-line": "### fun-line",

--- a/tools/governance/agent_registry_v1.json
+++ b/tools/governance/agent_registry_v1.json
@@ -35,7 +35,7 @@
     {
       "agent_id": "dev-bridge",
       "display_name": "Developer Bridge",
-      "status": "unavailable",
+      "status": "available",
       "role": "component-developer",
       "branch_hint": "dev/bridge",
       "scope": "bridge overlay/runtime and rollback-safe changes",
@@ -45,7 +45,7 @@
       "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-bridge-role",
       "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role bridge --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "no"
+      "can_receive_work_from_si": "yes"
     },
     {
       "agent_id": "dev-generic",
@@ -93,17 +93,17 @@
     {
       "agent_id": "dev-starter",
       "display_name": "Developer Starter",
-      "status": "unavailable",
+      "status": "available",
       "role": "component-developer",
       "branch_hint": "dev/starter",
       "scope": "starter component delivery lane",
       "owned_components": [
         "starter"
       ],
-      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#generic-developer-role",
-      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --mode mode-b",
+      "startup_prompt_path": "docs/agents/agent_role_start_prompts_v1.md#dev-starter-role",
+      "bootstrap_command": "bash tools/governance/agent_git_bootstrap_v1.sh --role starter --mode mode-b",
       "escalates_to": "si",
-      "can_receive_work_from_si": "no"
+      "can_receive_work_from_si": "yes"
     },
     {
       "agent_id": "dev-autoswitch",


### PR DESCRIPTION
Fixes bridge startup availability and adds a complete starter role (bootstrap/profile/prompt/registry/start-index/helper validation).