### PR TITLE
fix(governance): repair governed demand intake YAML syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/governed-demand-intake.yml
+++ b/.github/ISSUE_TEMPLATE/governed-demand-intake.yml
@@ -33,12 +33,12 @@ body:
     id: component
     attributes:
       label: Primary component suffix
-      description: Example: bridge, tuner, starter, autoswitch, fun-line, hardware, system-integration
+      description: "Example: bridge, tuner, starter, autoswitch, fun-line, hardware, system-integration"
   - type: input
     id: agent
     attributes:
       label: Preferred agent lane
-      description: Example: system-integration, bridge, tuner, ux
+      description: "Example: system-integration, bridge, tuner, ux"
   - type: textarea
     id: summary
     attributes:


### PR DESCRIPTION
## Summary
- repair the governed demand intake issue template YAML
- quote description values containing `Example:` so the form parses correctly
- keep the change minimal and scoped to the broken template

## Why
The template on `main` is syntactically invalid YAML because plain scalar values containing `:` followed by a space were left unquoted in two `description` fields.

## Scope
- `.github/ISSUE_TEMPLATE/governed-demand-intake.yml`

## Validation
- updated YAML parses successfully after the fix

## Rollback
- revert this PR
