### PR TITLE
docs(exchange): clarify ship-to-codex write path and preserve current handoff artifacts

### DIFF
--- a/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
+++ b/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
@@ -398,3 +398,10 @@ Priority rule:
 - owner can see `now`, `quick_win`, and `backlog` inventory from existing Git surfaces
 - implementation suggestions are explicit, ranked, and branchable
 - exchange cycles can be initialized and watched automatically through existing exchange scripts
+
+## Operational clarification — ChatGPT write branch for `ship to codex`
+- for ChatGPT-authored exchange artifact writes, the operational write branch is `integration/chatgpt`
+- this applies to live session artifacts, demand promotions, materialized protocol snapshots, inbox-main pickup snapshots, and raw ZIP handoff artifacts authored by ChatGPT
+- do not create a new `si/*` branch solely to perform a routine ChatGPT `ship to codex` handoff
+- `exchange/chatgpt/inbox-main/` remains the canonical pickup artifact namespace/contract; Codex owns any downstream normalization, promotion, target-branch fan-out, and PR preparation required by its workflow
+- historical/bootstrap references to `si/chatgpt-git-exchange-*` are retained for history/bootstrap context and are not the routine write path for current ChatGPT-authored handoffs

--- a/docs/agents/chatgpt_git_exchange_playbook_v1.md
+++ b/docs/agents/chatgpt_git_exchange_playbook_v1.md
@@ -4,14 +4,14 @@
 Provide a standard path for two-lane collaboration (ChatGPT + Codex) using Git artifacts with low owner effort and minimal knowledge loss.
 
 ## Quick start
-1. Run bootstrap on dedicated branch:
-   - `bash tools/governance/agent_git_bootstrap_v1.sh --role si --mode mode-b si/chatgpt-git-exchange-<topic>`
+1. Ensure the operational ChatGPT write branch is available:
+   - `integration/chatgpt`
 2. Activate governed mode:
    - `governed mode on`
-3. Create/update live session continuity artifact first:
+3. Create/update live session continuity artifact first on `integration/chatgpt`:
    - `exchange/chatgpt/sessions/<topic>__live_v1.md`
    - optional (recommended): initialize/refresh materialized protocol artifact `exchange/chatgpt/protocol-main/<topic>__protocol_v1.md`
-4. Promote with `ship to codex` into demand intake:
+4. Promote with `ship to codex` on `integration/chatgpt`:
    - `exchange/chatgpt/demands/<topic>__intake_v1.md` -> `ready-for-codex` (internal `chatok`)
    - publish canonical main pickup snapshot `exchange/chatgpt/inbox-main/<timestamp>__<topic>__intake_snapshot_v1.md` -> `pickup-ready`
    - helper: `python3 tools/governance/chatgpt_promote_live_to_demand_v1.py --topic \"<topic>\" --ship-to-codex`
@@ -44,7 +44,7 @@ If durable truth update is not ready, live session capture is mandatory and dema
 Use:
 
 ```bash
-python3 tools/governance/chatgpt_exchange_cycle_v1.py --topic "<topic>" --branch-plan "si/<topic>" --create-demand
+python3 tools/governance/chatgpt_exchange_cycle_v1.py --topic "<topic>" --branch-plan "integration/chatgpt" --create-demand
 ```
 
 This creates request/response files, an optional demand intake file, and appends a stream entry.
@@ -106,3 +106,8 @@ python3 tools/governance/chatgpt_no_shell_bundle_v1.py
 
 Then upload only:
 - `exchange/chatgpt/bundles/current_context_bundle_v1.md`
+
+## Operational clarification
+- routine ChatGPT-authored `ship to codex` writes happen on `integration/chatgpt`
+- do not open a fresh `si/*` branch just to write the exchange artifacts for a normal ChatGPT->Codex handoff
+- Codex remains responsible for any downstream target-branch fan-out, normalization manifest generation, PR creation, and execution reporting


### PR DESCRIPTION
## Summary
- preserve the current ChatGPT -> Codex handoff artifacts for appliance control / overlay / install stabilization on `integration/chatgpt`
- clarify in the ChatGPT exchange governance docs that routine ChatGPT-authored `ship to codex` writes happen on `integration/chatgpt`
- clarify that a normal ChatGPT handoff should not create a fresh `si/*` branch only to write exchange artifacts

## Why
The current handoff exposed ambiguity in the documented ChatGPT write path for `ship to codex`, which caused avoidable friction. This PR makes the operational rule explicit and keeps the current handoff documented on the intended integration branch.

## Scope
- `contracts/repo/chatgpt_git_exchange_operating_standard_v1.md`
- `docs/agents/chatgpt_git_exchange_playbook_v1.md`

## Current handoff artifacts already materialized on the integration lane
- `exchange/chatgpt/sessions/appliance-control-overlay-and-install-stabilization__live_v1.md`
- `exchange/chatgpt/demands/appliance-control-overlay-and-install-stabilization__intake_v1.md`
- `exchange/chatgpt/protocol-main/appliance-control-overlay-and-install-stabilization__protocol_v1.md`
- `exchange/chatgpt/inbox-main/20260417T191939Z__appliance-control-overlay-and-install-stabilization__intake_snapshot_v1.md`
- `exchange/chatgpt/streams/stream_v1.md`

## Notes
- compare currently shows `integration/chatgpt` ahead by documentation commits and behind `main` by one commit
- merge/rebase handling can proceed in the normal PR flow once checks complete
- accidentally created issue-based intake artifacts are not the canonical execution source for this handoff; the exchange artifacts above are

## Rollback
- revert this PR
