### PR TITLE
Exchange: implement `backup chat only` command semantics for autonomous flow

### DIFF
--- a/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
+++ b/contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
@@ -229,13 +229,14 @@ Required companion fields:
 ## Standard exchange loop (minimal owner path)
 1. ChatGPT activates governed mode with `governed mode on`.
 2. ChatGPT writes/updates live session artifact in `exchange/chatgpt/sessions/` (`status: live`).
-3. Owner requests `ship to codex`; Codex internalizes `chatok`, promotes live context into `exchange/chatgpt/demands/<topic>__intake_v1.md`, updates `exchange/chatgpt/protocol-main/<topic>__protocol_v1.md`, and publishes canonical main inbox snapshot `exchange/chatgpt/inbox-main/<timestamp>__<topic>__intake_snapshot_v1.md`.
-4. Demand is moved to `status: ready-for-codex`.
-5. Codex marks `status: in-execution` while implementing governed repo changes.
-6. Codex marks `status: ready-for-chatgpt-review` after implementation artifacts + PR are prepared.
-7. ChatGPT review is optional advisory input; when performed, set `status: pre-ok` or `status: changes-requested`.
-8. Codex updates owner packet and sets `status: ready-for-owner` when PR + rollback + evidence + next_owner_click are ready in repo truth (with or without ChatGPT review).
-9. Owner decides/merges; demand closes automatically after merge + governance closeout completion.
+3. Owner may request `backup chat only` for persistence-only updates (session/protocol continuity) without creating execution triggers.
+4. Owner requests `ship to codex`; Codex internalizes `chatok`, promotes live context into `exchange/chatgpt/demands/<topic>__intake_v1.md`, updates `exchange/chatgpt/protocol-main/<topic>__protocol_v1.md`, and publishes canonical main inbox snapshot `exchange/chatgpt/inbox-main/<timestamp>__<topic>__intake_snapshot_v1.md`.
+5. Demand is moved to `status: ready-for-codex`.
+6. Codex marks `status: in-execution` while implementing governed repo changes.
+7. Codex marks `status: ready-for-chatgpt-review` after implementation artifacts + PR are prepared.
+8. ChatGPT review is optional advisory input; when performed, set `status: pre-ok` or `status: changes-requested`.
+9. Codex updates owner packet and sets `status: ready-for-owner` when PR + rollback + evidence + next_owner_click are ready in repo truth (with or without ChatGPT review).
+10. Owner decides/merges; demand closes automatically after merge + governance closeout completion.
 
 ## Living exchange stream (mandatory)
 - active stream file: `exchange/chatgpt/streams/stream_v1.md`

--- a/docs/agents/chatgpt_capture_to_demand_prompt_v1.md
+++ b/docs/agents/chatgpt_capture_to_demand_prompt_v1.md
@@ -45,7 +45,9 @@ in-execution -> ready-for-chatgpt-review -> pre-ok -> ready-for-owner -> closed
 
 Owner command surface must stay minimal:
 - governed mode on
+- backup chat only (persistence only; no execution trigger)
 - ship to codex
+- review now
 - merge when PR is decision-ready on repo truth (`pre-ok` optional advisory)
 ```
 

--- a/docs/agents/chatgpt_owner_quickstart_v1.md
+++ b/docs/agents/chatgpt_owner_quickstart_v1.md
@@ -6,9 +6,10 @@ Provide the minimum owner command path for governed ChatGPT↔Codex operation.
 ## Canonical owner command sequence
 1. `governed mode on`
 2. discussion
-3. `ship to codex`
-4. `review now`
-5. merge to `main` when PR is decision-ready on repo truth (`pre-ok` optional advisory)
+3. `backup chat only` (optional persistence-only checkpoint; no Codex execution trigger)
+4. `ship to codex` (execution trigger)
+5. `review now`
+6. merge to `main` when PR is decision-ready on repo truth (`pre-ok` optional advisory)
 
 ## Review pickup marker (single source)
 Use demand artifacts under `exchange/chatgpt/demands/` and locate:
@@ -24,6 +25,7 @@ Required references in the same demand:
 - `chatok` and demand closeout remain internal automation/lifecycle mechanics.
 - ChatGPT `pre-ok` remains optional advisory; owner can decide directly from repo-truth packet and PR evidence.
 - owner does not need to tell Codex which side branch to inspect; `ship to codex` publishes canonical pickup snapshot under `exchange/chatgpt/inbox-main/` on `main`.
+- `backup chat only` persists continuity artifacts only (live session/protocol update) and must not create demand `ready-for-codex` or inbox-main `pickup-ready` trigger artifacts.
 
 ## Guardrails
 - no new dashboard/board/html surfaces are required for this flow

--- a/docs/agents/owner_operational_reference_v1.md
+++ b/docs/agents/owner_operational_reference_v1.md
@@ -86,6 +86,7 @@ Packet contract:
 
 ## Owner minimal command surface (canonical)
 - `governed mode on`
+- `backup chat only` (optional persistence-only; no execution trigger)
 - `ship to codex`
 - `review now`
 - merge to `main` when PR is decision-ready on repo truth (`pre-ok` optional)

--- a/exchange/chatgpt/PROTOCOL_v1.md
+++ b/exchange/chatgpt/PROTOCOL_v1.md
@@ -43,6 +43,17 @@ Detailed behavior:
 8. Codex prepares owner packet and sets `status: ready-for-owner` once PR + rollback + evidence + next_owner_click are ready in repo truth (independent of ChatGPT review presence).
 9. After owner decision/merge and governance closeout completion, demand status is auto-moved to `closed`.
 
+## Backup-only command rule
+- owner command: `backup chat only`
+- intent: persist current chat continuity without starting Codex execution
+- required outputs:
+  - update `exchange/chatgpt/sessions/<topic>__live_v1.md` material state/timestamp
+  - optional compact event append in `exchange/chatgpt/protocol-main/<topic>__protocol_v1.md`
+- must not create execution triggers:
+  - no demand status transition to `ready-for-codex`
+  - no new inbox-main snapshot with `status: pickup-ready`
+- `ship to codex` remains the only owner-visible execution trigger command.
+
 Override constraints:
 - if override markers are used, they remain explicit and auditable
 - override must not be represented as `pre-ok`

--- a/exchange/chatgpt/demands/chat-backup-only-command__intake_v1.md
+++ b/exchange/chatgpt/demands/chat-backup-only-command__intake_v1.md
@@ -1,6 +1,6 @@
 # chat-backup-only-command intake v1
 
-status: ready-for-codex
+status: ready-for-owner
 actor: chatgpt
 
 ## source/context
@@ -64,11 +64,14 @@ actor: chatgpt
 - label_truth_rule: labels route/query only; repo sections in this file remain canonical detailed truth
 
 ## lifecycle tracking
-- source_pr_url:
-- source_branch:
-- review_target_artifacts:
-- chatgpt_review_result: pending
+- codex_trigger: ship-to-codex
+- materialized_protocol: exchange/chatgpt/protocol-main/chat-backup-only-command__protocol_v1.md
+- main_inbox_snapshot: exchange/chatgpt/inbox-main/20260417T202000Z__chat-backup-only-command__intake_snapshot_v1.md
+- source_pr_url: https://github.com/SH99999/mediastreamer/pull/167
+- source_branch: si/chat-backup-only-command-v1
+- review_target_artifacts: docs/agents/chatgpt_owner_quickstart_v1.md; docs/agents/owner_operational_reference_v1.md; docs/agents/chatgpt_capture_to_demand_prompt_v1.md; exchange/chatgpt/PROTOCOL_v1.md; contracts/repo/chatgpt_git_exchange_operating_standard_v1.md
+- chatgpt_review_result: optional-not-run
 - owner_review_override: no
 - owner_override_note:
-- governance_closeout_status: pending
-- next_owner_click: wait for Codex PR and ChatGPT review
+- governance_closeout_status: in-pr
+- next_owner_click: review PR #167 and decide `accept | changes-requested | reject`

--- a/exchange/chatgpt/inbox-main/20260417T202000Z__chat-backup-only-command__intake_snapshot_v1.md
+++ b/exchange/chatgpt/inbox-main/20260417T202000Z__chat-backup-only-command__intake_snapshot_v1.md
@@ -1,0 +1,34 @@
+# chat-backup-only-command intake snapshot v1
+
+status: closed
+pickup_rule: main-inbox-v1
+snapshot_immutable: true
+snapshot_id: 20260417T202000Z
+created_at_utc: 2026-04-17T20:20:00Z
+trigger_command: ship to codex
+close_reason: codex-implementation-ready; owner review pending
+
+## codex pickup contract
+- execution_branch: si/chat-backup-only-command-v1
+- pickup_ready_marker: status: pickup-ready
+- pickup_source: exchange/chatgpt/inbox-main/
+
+## source artifacts
+- demand_intake: exchange/chatgpt/demands/chat-backup-only-command__intake_v1.md
+- materialized_protocol: exchange/chatgpt/protocol-main/chat-backup-only-command__protocol_v1.md
+
+## objective
+- implement an explicit `backup chat only` command that preserves continuity without triggering execution.
+
+## locked decisions
+1. `backup chat only` must not create demand `ready-for-codex` or inbox-main `pickup-ready` execution triggers.
+2. `ship to codex` remains the only owner-visible command that starts Codex execution pickup.
+
+## open decisions
+1. none
+
+## risks
+1. command-surface confusion if docs drift between quickstart, owner reference, protocol, and exchange standard.
+
+## execution requests
+1. update owner/protocol/governance docs and publish decision-ready packet.

--- a/exchange/chatgpt/protocol-main/chat-backup-only-command__protocol_v1.md
+++ b/exchange/chatgpt/protocol-main/chat-backup-only-command__protocol_v1.md
@@ -1,0 +1,28 @@
+# chat-backup-only-command protocol v1
+
+status: ready-for-owner
+topic: chat-backup-only-command
+last_updated_utc: 2026-04-17T21:15:00Z
+
+## event history
+
+### event-001
+- timestamp_utc: 2026-04-17T10:35:00Z
+- event_type: ship-to-codex-promotion
+- summary: chat topic promoted as governed demand for implementing a persistence-only `backup chat only` command behavior.
+- links:
+  - demand_intake: exchange/chatgpt/demands/chat-backup-only-command__intake_v1.md
+  - live_session: exchange/chatgpt/sessions/chat-backup-only-command__live_v1.md
+
+### event-002
+- timestamp_utc: 2026-04-17T21:15:00Z
+- event_type: codex-implementation-ready
+- summary: owner/protocol/governance docs updated so `backup chat only` persists continuity only and does not trigger Codex execution.
+- links:
+  - source_branch: si/chat-backup-only-command-v1
+  - review_targets:
+    - docs/agents/chatgpt_owner_quickstart_v1.md
+    - docs/agents/owner_operational_reference_v1.md
+    - docs/agents/chatgpt_capture_to_demand_prompt_v1.md
+    - exchange/chatgpt/PROTOCOL_v1.md
+    - contracts/repo/chatgpt_git_exchange_operating_standard_v1.md

--- a/exchange/chatgpt/streams/stream_v1.md
+++ b/exchange/chatgpt/streams/stream_v1.md
@@ -64,6 +64,14 @@
 - owner decision needed: `none`
 - status: `ready-for-codex`
 
+### 2026-04-17 / cycle chat-backup-only-command / codex-implementation
+- actor: `codex`
+- source file: `exchange/chatgpt/demands/chat-backup-only-command__intake_v1.md`
+- action: implemented canonical `backup chat only` semantics in owner/protocol/governance docs (persistence-only, no execution trigger)
+- branch plan: `si/chat-backup-only-command-v1`
+- owner decision needed: `accept | changes-requested | reject`
+- status: `ready-for-owner`
+
 ### 2026-04-17 / cycle appliance-control-overlay-and-install-stabilization / ship-to-codex
 - actor: `chatgpt`
 - source file: `exchange/chatgpt/demands/appliance-control-overlay-and-install-stabilization__intake_v1.md`


### PR DESCRIPTION
Implements the open `chat-backup-only-command` demand and makes backup-only persistence explicit without triggering Codex execution.